### PR TITLE
Mmd file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 
 ### [v0.0.2]
 - Add support for complex graph cases
+- Add Mermaid language and support for .mmd files

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # vscode-mermaid-syntax-highlight
-Markdown syntax support for the [Mermaid charting language](https://github.com/knsv/mermaid)
+Syntax support for the [Mermaid charting language](https://github.com/knsv/mermaid)
 
 [![Version](https://vsmarketplacebadge.apphb.com/version/bpruitt-goddard.mermaid-markdown-syntax-highlighting.svg)](https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting) [![Installs](https://vsmarketplacebadge.apphb.com/installs/bpruitt-goddard.mermaid-markdown-syntax-highlighting.svg)](https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting) [![Ratings](https://vsmarketplacebadge.apphb.com/rating/bpruitt-goddard.mermaid-markdown-syntax-highlighting.svg)](https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting)
+
+Supports both fenced markdown (see screenshots), and mmd files.
 
 ## Screenshots/Progress
 
@@ -123,4 +125,4 @@ Based on the starter language support repo [here](https://github.com/mjbvz/vscod
 - [x] Graph support
 - [x] Sequence Diagram support
 - [ ] Gantt support
-- [ ] Support highlighting in other formats (mermaid file, html tag, etc?)
+- [x] Support highlighting in mmd files.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,18 @@
     "Other"
   ],
   "contributes": {
+    "languages": [
+      {
+        "id": "Mermaid",
+        "extensions": [ ".mmd" ]
+      }
+    ],
     "grammars": [
+      {
+        "language": "Mermaid",
+        "scopeName": "markdown.mermaid.codeblock",
+        "path": "./syntaxes/codeblock.json"
+      },
       {
         "scopeName": "markdown.mermaid.codeblock",
         "path": "./syntaxes/codeblock.json",
@@ -20,7 +31,7 @@
           "text.html.markdown"
         ],
         "embeddedLanguages": {
-          "meta.embedded.block.mermaid": "mermaid"
+          "meta.embedded.block.mermaid": "Mermaid"
         }
       }
     ]

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -7,10 +7,15 @@
 		}
 	],
 	"repository": {
-		"mermaid-code-block": {
+        "mermaid-code-block": {
 			"begin": "(?<=[`~])mermaid(\\s+[^`~]*)?$",
 			"end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
 			"patterns": [
+                { "include": "#mermaid" }
+			]
+        },
+        "mermaid": {
+            "patterns": [
                 {
                     "comment": "Graph",
                     "begin": "\\b(graph)\\s+([A-Za-z\\ 0-9]+)",
@@ -331,8 +336,8 @@
                     ],
                     "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)"
                 }
-			]
-		}
+            ]
+        }
 	},
 	"scopeName": "markdown.mermaid.codeblock"
 }

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -4,7 +4,10 @@
 	"patterns": [
 		{
 			"include": "#mermaid-code-block"
-		}
+        },
+        {
+            "include": "#mermaid"
+        }
 	],
 	"repository": {
         "mermaid-code-block": {


### PR DESCRIPTION
Fixes issue #10 . Registers `Mermaid` language and links `.mmd` files. Moved the grammar into a separate variable to allow for it to be picked up both raw (in `mmd` files) and nested in markdown fencing.