### PR TITLE
Correct prepublish script name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,6 @@
     - Autonumber
     - Par blocks
     - Rect (color) blocks
+
+### [v1.2.2]
+- Fix bug in new prepublish build step causing extension to break

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"mermaid"
 	],
 	"scripts": {
-		"prepublish": "npm run convertYaml",
+		"vscode:prepublish": "npm run convertYaml",
 		"convertYaml": "node build/ConvertYaml.js"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "mermaid-markdown-syntax-highlighting",
 	"displayName": "Mermaid Markdown Syntax Highlighting",
 	"description": "Markdown syntax support for the Mermaid charting language",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"publisher": "bpruitt-goddard",
 	"license": "MIT",
 	"engines": {


### PR DESCRIPTION
The `prepublish` script was using the wrong script name, thus not triggering when publishing the extension. The proper name is found from [these docs](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prepublish-step).