### PR TITLE
modify "contributes.languages.id" in order to apply the grammar to .mmd files correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"contributes": {
 		"languages": [
 			{
-				"id": "Mermaid",
+				"id": "mermaid",
 				"extensions": [
 					".mmd"
 				]
@@ -22,7 +22,7 @@
 		],
 		"grammars": [
 			{
-				"language": "Mermaid",
+				"language": "mermaid",
 				"scopeName": "markdown.mermaid.codeblock",
 				"path": "./out/mermaid.tmLanguage.json"
 			},


### PR DESCRIPTION
Hello. Thank you for providing really great extension!
I found the grammar isn't applied correctly in a `.mmd ` file. It seems to be caused by the capital letter in the language ID. I could confirm it worked fine at my local. I'm glad if this PR helps to improve this package.