### PR TITLE
Create Github Action To Auto-Deploy

### DIFF
--- a/.github/workflows/master-merge.yml
+++ b/.github/workflows/master-merge.yml
@@ -1,0 +1,37 @@
+# Deploy to VS Marketplace on master merge as long as the version has
+# changed (inferred by a change to CHANGELOG.md)
+
+name: 'Github Master Merge'
+
+on:
+  pull_request:
+    types:
+      - closed
+    paths:
+      - 'CHANGELOG.md'
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.4.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com


### PR DESCRIPTION
Stop dealing with manual local deploys when Github Actions can handle it.

This action is deployed on PR merges. To avoid issues of trying to publish a duplicate version (such as when a PR is merged that does **not** bump the version), this action only runs when the `CHANGELOG.md` file is updated (inferring that a new version must have been made).