### PR TITLE
Fix Sequence Title and Participant Whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,7 @@
 
 ### [v1.3.3]
 - Add sequence diagram actor support
+
+### [v1.3.4]
+- Fix sequence diagram title whitespace
+- Fix sequence diagram actor/participant whitespace

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "mermaid-markdown-syntax-highlighting",
 	"displayName": "Mermaid Markdown Syntax Highlighting",
 	"description": "Markdown syntax support for the Mermaid charting language",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"publisher": "bpruitt-goddard",
 	"license": "MIT",
 	"engines": {

--- a/syntaxes/diagrams/sequenceDiagram.yaml
+++ b/syntaxes/diagrams/sequenceDiagram.yaml
@@ -20,8 +20,8 @@
     - comment: '(participant)(Actor)(as)?(Label)?'
       match: !regex |-
         \s*(participant|actor) # participant
-        \s+(["\(\)$&%\^/#.?!*=<>\'\\\w\s]+?) # Actor
-        (?:\s+(as))? # as?
+        \s+((?:(?! as )["\(\)$&%\^/#.?!*=<>\'\\\w\s])+) # Actor
+        \s*(as)? # as?
         \s(["\(\)$&%\^/#.,?!*=<>\'\\\w\s]+)? # Label?
       captures:
         '1':

--- a/syntaxes/diagrams/sequenceDiagram.yaml
+++ b/syntaxes/diagrams/sequenceDiagram.yaml
@@ -6,9 +6,9 @@
   patterns:
     - match: (\%%|#).*
       name: comment
-    - comment: '(title)'
+    - comment: '(title)(title text)'
       match: !regex |-
-        (title)\s*(:)\s+ # title
+        (title)\s*(:)?\s+ # title
         (\s*["\(\)$&%\^/#.,?!:*+=<>\'\\\-\w\s]*) # text
       captures:
         '1':

--- a/tests/diagrams/sequence.test.mermaid
+++ b/tests/diagrams/sequence.test.mermaid
@@ -8,11 +8,11 @@ sequenceDiagram
   participant Alice
 %%^^^^^^^^^^^ keyword.control.mermaid
 %%            ^^^^^ variable
-  participant B as Bob<br>Newline
+  participant B NewasLine as Bob<br>Newline
 %%^^^^^^^^^^^ keyword.control.mermaid
-%%            ^ variable 
-%%              ^^ keyword.control.mermaid 
-%%                 ^^^^^^^^^^^^^^ string
+%%            ^^^^^^^^^^^ variable 
+%%                        ^^ keyword.control.mermaid 
+%%                           ^^^^^^^^^^^^^^ string
   participant C as Carol
 %%^^^^^^^^^^^ keyword.control.mermaid
 %%            ^ variable 

--- a/tests/diagrams/sequence.test.mermaid
+++ b/tests/diagrams/sequence.test.mermaid
@@ -23,6 +23,12 @@ sequenceDiagram
 %%      ^ variable 
 %%        ^^ keyword.control.mermaid 
 %%           ^^^^^^^^^^^^^^^^ string
+  title Test Diagram
+%%^^^^^ keyword.control.mermaid
+%%      ^^^^^^^^^^^^ string
+  title: Alternate title style
+%%^^^^^^ keyword.control.mermaid
+%%       ^^^^^^^^^^^^^^^^^^^^^ string
   %% arrows
   B->C: Solid line without arrow
 %%^ variable


### PR DESCRIPTION
Fixes whitespace in title for #76 

<img width="263" alt="image" src="https://user-images.githubusercontent.com/2429731/183341964-6775f143-c4c1-4d93-ac7f-395ec128886e.png">

Fixes whitespace in participant/actors for #43 

<img width="421" alt="image" src="https://user-images.githubusercontent.com/2429731/183342082-4ae6d9d6-5c2c-4dbf-a17c-d505f2d8a410.png">
