### PR TITLE
Add Prettier Validation To Github PR Workflow

### DIFF
--- a/.github/workflows/github-pr.yml
+++ b/.github/workflows/github-pr.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Prettier check
+        uses: creyD/prettier_action@v4.2
+        with:
+          dry: true
+          prettier_options: --check **/*.{js,yaml,md}
+
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,69 +1,89 @@
 ## Change Log
 
 ### [v0.0.1]
+
 - Initial release with flowchart/graph and sequence diagram support
 
 ### [v0.0.2]
+
 - Add support for complex graph cases
 - Add Mermaid language and support for .mmd files
 
 ### [v1.0.0]
+
 - Added gantt support, completing support for all 3 graph types
 
 ### [v1.0.1]
+
 - Allow more punctuation in graph and gantt text
 
 ### [v1.0.2]
+
 - Add pie chart support
 
 ### [v1.0.3]
+
 - Fix sequence diagram participant label highlighting
 
 ### [v1.0.4]
+
 - Fix sequence diagram entity text highlighting
 
 ### [v1.0.5]
+
 - Add basic flowchart support
 
 ### [v1.1.0]
+
 - Add class diagram support
 
 ### [v1.2.0]
+
 - Add state diagram support
 
 ### [v1.2.1]
+
 - Update sequence diagram support with:
-    - Async arrows
-    - Autonumber
-    - Par blocks
-    - Rect (color) blocks
+  - Async arrows
+  - Autonumber
+  - Par blocks
+  - Rect (color) blocks
 
 ### [v1.2.2]
+
 - Fix bug in new prepublish build step causing extension to break
 
 ### [v1.2.3]
+
 - Fix bug preventing .mmd files from being properly highlighted
 - Add support in graphs for nodes with id only
 
 ### [v1.2.4]
+
 - Add ADO syntax support
 
 ### [v1.3.0]
+
 - Add entity relationship diagram support
 
 ### [v1.3.1]
+
 - Add classDiagram reversed arrow support
 
 ### [v1.3.2]
+
 - Add graph diagram double arrow support
 - Add class diagram multiple parameter support
 
 ### [v1.3.3]
+
 - Add sequence diagram actor support
 
 ### [v1.3.4]
+
 - Fix sequence diagram title whitespace
 - Fix sequence diagram actor/participant whitespace
 
 ### [v1.4.0]
+
 - Add git graph support

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,14 +3,18 @@
 The grammars for each diagram type reside in `syntaxes/diagrams` in separate files.
 
 To test changes locally:
+
 1. Build the theme and create the vsix package by running:
+
 ```sh
 npm install
 vsce package
 ```
+
 2. Install the theme locally by using the `Install from VSIX` command. This may require reloading VS Code to see the changes.
 
 ## Testing
+
 There are tests validating the grammar that can be triggered by running:
 
 ```sh
@@ -20,7 +24,7 @@ npm test
 The tests will validate the grammar for all diagrams. Note this does _not_ build the grammar, this will need to be done if changes have been made to the `yaml`. To test and build, run:
 
 ```sh
-npm run convertYaml && npm test  
+npm run convertYaml && npm test
 ```
 
 ## Developing

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Supports highlighting in Azure Dev Ops (ADO) colon syntax:
 
 Based on the starter language support repo [here](https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example), and initially created based on the Atom language support [here](https://github.com/ytisf/language-mermaid).
 
-
 ## Contributing
 
 For information on how to build/test/contribute, see the [Contributing Guide](CONTRIBUTING.md).

--- a/build/ConvertYaml.js
+++ b/build/ConvertYaml.js
@@ -1,25 +1,28 @@
-"use strict";
+'use strict';
 
 var fs = require('fs-extra');
-var GRAMMAR_SCHEMA = require("./CustomYamlTypes").GRAMMAR_SCHEMA;
+var GRAMMAR_SCHEMA = require('./CustomYamlTypes').GRAMMAR_SCHEMA;
 var read = require('yaml-import').read;
 var path = require('path');
 
 const FILE_DIR = '../syntaxes/',
-    DIR_OUT = '../out',
-    INPUT_DIR = path.join(__dirname, FILE_DIR),
-    OUTPUT_DIR = path.join(__dirname, DIR_OUT);
+  DIR_OUT = '../out',
+  INPUT_DIR = path.join(__dirname, FILE_DIR),
+  OUTPUT_DIR = path.join(__dirname, DIR_OUT);
 
 fs.ensureDirSync(path.join(__dirname, DIR_OUT));
 
 fs.readdirSync(path.join(__dirname, FILE_DIR))
-    .filter(file => path.extname(file) === '.yaml')
-    .forEach(file => {
-        var inputName = path.join(INPUT_DIR, file);
-        var outputName = path.join(OUTPUT_DIR, path.parse(inputName).name + ".json");
-        var res = read(inputName, null, GRAMMAR_SCHEMA) ;
-        
-        fs.writeFileSync(outputName, JSON.stringify(res, null, 2), {
-            encoding: "utf8"
-        });
+  .filter((file) => path.extname(file) === '.yaml')
+  .forEach((file) => {
+    var inputName = path.join(INPUT_DIR, file);
+    var outputName = path.join(
+      OUTPUT_DIR,
+      path.parse(inputName).name + '.json'
+    );
+    var res = read(inputName, null, GRAMMAR_SCHEMA);
+
+    fs.writeFileSync(outputName, JSON.stringify(res, null, 2), {
+      encoding: 'utf8',
     });
+  });

--- a/build/CustomYamlTypes.js
+++ b/build/CustomYamlTypes.js
@@ -1,40 +1,44 @@
 'use strict';
 
-var fs   = require('fs');
+var fs = require('fs');
 var path = require('path');
 var util = require('util');
 var yaml = require('js-yaml');
 
-
 var RegexYamlType = new yaml.Type('!regex', {
   kind: 'scalar',
   construct: function (data) {
-    return data
-      //Remove end of line comments (space then #)
-      .replace(/(^|\s)#.*/g, '')
-      //Remove new lines from yaml multistring
-      .replace(/\n/g, '');
-  }
+    return (
+      data
+        //Remove end of line comments (space then #)
+        .replace(/(^|\s)#.*/g, '')
+        //Remove new lines from yaml multistring
+        .replace(/\n/g, '')
+    );
+  },
 });
 
-var GRAMMAR_SCHEMA = yaml.Schema.create(yaml.SAFE_SCHEMA, [ RegexYamlType ]);
+var GRAMMAR_SCHEMA = yaml.Schema.create(yaml.SAFE_SCHEMA, [RegexYamlType]);
 
 // do not execute the following if file is required (http://stackoverflow.com/a/6398335)
 if (require.main === module) {
-
   // And read a document using that schema.
-  fs.readFile(path.join(__dirname, 'custom_types.yml'), 'utf8', function (error, data) {
-    var loaded;
+  fs.readFile(
+    path.join(__dirname, 'custom_types.yml'),
+    'utf8',
+    function (error, data) {
+      var loaded;
 
-    if (!error) {
-      loaded = yaml.load(data, { schema: GRAMMAR_SCHEMA });
-      console.log(util.inspect(loaded, false, 20, true));
-    } else {
-      console.error(error.stack || error.message || String(error));
+      if (!error) {
+        loaded = yaml.load(data, { schema: GRAMMAR_SCHEMA });
+        console.log(util.inspect(loaded, false, 20, true));
+      } else {
+        console.error(error.stack || error.message || String(error));
+      }
     }
-  });
+  );
 }
 
 // There are some exports to play with this example interactively.
 module.exports.RegexYamlType = RegexYamlType;
-module.exports.GRAMMAR_SCHEMA  = GRAMMAR_SCHEMA;
+module.exports.GRAMMAR_SCHEMA = GRAMMAR_SCHEMA;

--- a/syntaxes/diagrams/classDiagram.yaml
+++ b/syntaxes/diagrams/classDiagram.yaml
@@ -4,202 +4,87 @@
     '1':
       name: keyword.control.mermaid
   patterns:
-  - match: \%%.*
-    name: comment
-  - comment: '(class name) ("multiplicity relationship")? (relationship) ("multiplicity relationship")? (class name) :? (labelText)?'
-    match: !regex |-
-      ([\w-]+) # class name
-      \s("(?:\d+|\*|0..\d+|1..\d+|1..\*)")? # multiplicity relationship
-      \s?(--o|--\*|\<--|--\>|<\.\.|\.\.\>|\<\|\.\.|\.\.\|\>|\<\|--|--\|>|--\*|--|\.\.|\*--|o--) # relationship
-      \s("(?:\d+|\*|0..\d+|1..\d+|1..\*)")? # multiplicity relationship
-      \s?([\w-]+) # class name
-      \s?(:)? # :
-      \s(.*)$ # label text
-    captures:
-      '1':
-        name: entity.name.type.class.mermaid
-      '2':
-        name: keyword.control.mermaid
-      '3':
-        name: keyword.control.mermaid
-      '4':
-        name: keyword.control.mermaid
-      '5':
-        name: entity.name.type.class.mermaid
-      '6':
-        name: keyword.control.mermaid
-      '7':
-        name: string
-  - comment: '(class name) : (visibility)?(function)( (function param/generic param)? )(classifier)? (return/generic return)?$'
-    match: !regex |-
-      ([\w-]+) # class name
-      \s?(:) # :
-      \s([\+~#-])? # visibility
-      ([\w-]+) # function name
-      (\() # (
-      ([\w-]+)? # function param
-      (~)? # ~
-      ([\w-]+)? # generic function param
-      (~)? # ~
-      \s?([\w-]+)? # function name
-      (\)) # )
-      ([*\$])? # classifier
-      \s?([\w-]+)? # return type
-      (~)? # ~
-      ([\w-]+)? # generic return type
-      (~)?$ # ~
-    captures:
-      '1':
-        name: entity.name.type.class.mermaid
-      '2':
-        name: keyword.control.mermaid
-      '3':
-        name: keyword.control.mermaid
-      '4':
-        name: entity.name.function.mermaid
-      '5':
-        name: punctuation.parenthesis.open.mermaid
-      '6':
-        name: storage.type.mermaid
-      '7':
-        name: punctuation.definition.typeparameters.begin.mermaid
-      '8':
-        name: storage.type.mermaid
-      '9':
-        name: punctuation.definition.typeparameters.end.mermaid
-      '10':
-        name: entity.name.variable.parameter.mermaid
-      '11':
-        name: punctuation.parenthesis.closed.mermaid
-      '12':
-        name: keyword.control.mermaid
-      '13':
-        name: storage.type.mermaid
-      '14':
-        name: punctuation.definition.typeparameters.begin.mermaid
-      '15':
-        name: storage.type.mermaid
-      '16':
-        name: punctuation.definition.typeparameters.end.mermaid
-  - comment: '(class name) : (visibility)?(datatype/generic data type) (attribute name)$'
-    match: !regex |-
-      ([\w-]+) # class name
-      \s?(:) # :
-      \s([\+~#-])? # visibility
-      ([\w-]+) # datatype
-      (~)? # ~
-      ([\w-]+)? # datatype
-      (~)? # ~
-      \s([\w-]+)?$ # attribute name
-    captures:
-      '1':
-        name: entity.name.type.class.mermaid
-      '2':
-        name: keyword.control.mermaid
-      '3':
-        name: keyword.control.mermaid
-      '4':
-        name: storage.type.mermaid
-      '5':
-        name: punctuation.definition.typeparameters.begin.mermaid
-      '6':
-        name: storage.type.mermaid
-      '7':
-        name: punctuation.definition.typeparameters.end.mermaid
-      '8':
-        name: entity.name.variable.field.mermaid
-  - comment: '<<(Annotation)>> (class name)'
-    match: !regex |-
-      (<<) # <<
-      ([\w-]+) # annotation
-      (>>) # >>
-      \s?([\w-]+)? # class name
-    captures:
-        '1':
-          name: punctuation.definition.typeparameters.begin.mermaid
-        '2':
-          name: storage.type.mermaid
-        '3':
-          name: punctuation.definition.typeparameters.end.mermaid
-        '4':
-          name: entity.name.type.class.mermaid
-  - comment: 'class (class name) ~?(generic type)?~? ({)'
-    begin: !regex |-
-      (class)\s+ #class
-      ([\w-]+) # class name
-      (~)? # ~
-      ([\w-]+)? # generic type name
-      (~)? # ~
-      \s?({) # begin bracket
-    beginCaptures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: entity.name.type.class.mermaid
-      '3':
-        name: punctuation.definition.typeparameters.begin.mermaid
-      '4':
-        name: storage.type.mermaid
-      '5':
-        name: punctuation.definition.typeparameters.end.mermaid
-      '6':
-        name: keyword.control.mermaid
-    patterns:
     - match: \%%.*
       name: comment
-    - comment: '(visibility)?(function)( (function param/generic param)? )(classifier)? (return/generic return)?$'
-      begin: !regex |-
+    - comment: '(class name) ("multiplicity relationship")? (relationship) ("multiplicity relationship")? (class name) :? (labelText)?'
+      match: !regex |-
+        ([\w-]+) # class name
+        \s("(?:\d+|\*|0..\d+|1..\d+|1..\*)")? # multiplicity relationship
+        \s?(--o|--\*|\<--|--\>|<\.\.|\.\.\>|\<\|\.\.|\.\.\|\>|\<\|--|--\|>|--\*|--|\.\.|\*--|o--) # relationship
+        \s("(?:\d+|\*|0..\d+|1..\d+|1..\*)")? # multiplicity relationship
+        \s?([\w-]+) # class name
+        \s?(:)? # :
+        \s(.*)$ # label text
+      captures:
+        '1':
+          name: entity.name.type.class.mermaid
+        '2':
+          name: keyword.control.mermaid
+        '3':
+          name: keyword.control.mermaid
+        '4':
+          name: keyword.control.mermaid
+        '5':
+          name: entity.name.type.class.mermaid
+        '6':
+          name: keyword.control.mermaid
+        '7':
+          name: string
+    - comment: '(class name) : (visibility)?(function)( (function param/generic param)? )(classifier)? (return/generic return)?$'
+      match: !regex |-
+        ([\w-]+) # class name
+        \s?(:) # :
         \s([\+~#-])? # visibility
         ([\w-]+) # function name
         (\() # (
-      beginCaptures:
-        '1':
-          name: keyword.control.mermaid
-        '2':
-          name: entity.name.function.mermaid
-        '3':
-          name: punctuation.parenthesis.open.mermaid
-      patterns:
-      - comment: (TBD)
-        match: !regex |-
-          \s*,?\s*([\w-]+)? # function param
-          (~)? # ~
-          ([\w-]+)? # generic function param
-          (~)? # ~
-          \s?([\w-]+)? # function name
-        captures:
-          '1':
-            name: storage.type.mermaid
-          '2':
-            name: punctuation.definition.typeparameters.begin.mermaid
-          '3':
-            name: storage.type.mermaid
-          '4':
-            name: punctuation.definition.typeparameters.end.mermaid
-          '5':
-            name: entity.name.variable.parameter.mermaid
-      end: !regex |-
+        ([\w-]+)? # function param
+        (~)? # ~
+        ([\w-]+)? # generic function param
+        (~)? # ~
+        \s?([\w-]+)? # function name
         (\)) # )
         ([*\$])? # classifier
         \s?([\w-]+)? # return type
         (~)? # ~
         ([\w-]+)? # generic return type
         (~)?$ # ~
-      endCaptures:
+      captures:
         '1':
-          name: punctuation.parenthesis.closed.mermaid
+          name: entity.name.type.class.mermaid
         '2':
           name: keyword.control.mermaid
         '3':
-          name: storage.type.mermaid
+          name: keyword.control.mermaid
         '4':
-          name: punctuation.definition.typeparameters.begin.mermaid
+          name: entity.name.function.mermaid
         '5':
-          name: storage.type.mermaid
+          name: punctuation.parenthesis.open.mermaid
         '6':
+          name: storage.type.mermaid
+        '7':
+          name: punctuation.definition.typeparameters.begin.mermaid
+        '8':
+          name: storage.type.mermaid
+        '9':
           name: punctuation.definition.typeparameters.end.mermaid
-    - comment: '(visibility)?(datatype/generic data type) (attribute name)$'
+        '10':
+          name: entity.name.variable.parameter.mermaid
+        '11':
+          name: punctuation.parenthesis.closed.mermaid
+        '12':
+          name: keyword.control.mermaid
+        '13':
+          name: storage.type.mermaid
+        '14':
+          name: punctuation.definition.typeparameters.begin.mermaid
+        '15':
+          name: storage.type.mermaid
+        '16':
+          name: punctuation.definition.typeparameters.end.mermaid
+    - comment: '(class name) : (visibility)?(datatype/generic data type) (attribute name)$'
       match: !regex |-
+        ([\w-]+) # class name
+        \s?(:) # :
         \s([\+~#-])? # visibility
         ([\w-]+) # datatype
         (~)? # ~
@@ -208,16 +93,20 @@
         \s([\w-]+)?$ # attribute name
       captures:
         '1':
-          name: keyword.control.mermaid
+          name: entity.name.type.class.mermaid
         '2':
-          name: storage.type.mermaid
+          name: keyword.control.mermaid
         '3':
-          name: punctuation.definition.typeparameters.begin.mermaid
+          name: keyword.control.mermaid
         '4':
           name: storage.type.mermaid
         '5':
-          name: punctuation.definition.typeparameters.end.mermaid
+          name: punctuation.definition.typeparameters.begin.mermaid
         '6':
+          name: storage.type.mermaid
+        '7':
+          name: punctuation.definition.typeparameters.end.mermaid
+        '8':
           name: entity.name.variable.field.mermaid
     - comment: '<<(Annotation)>> (class name)'
       match: !regex |-
@@ -226,35 +115,146 @@
         (>>) # >>
         \s?([\w-]+)? # class name
       captures:
-          '1':
-            name: punctuation.definition.typeparameters.begin.mermaid
-          '2':
-            name: storage.type.mermaid
-          '3':
-            name: punctuation.definition.typeparameters.end.mermaid
-          '4':
-            name: entity.name.type.class.mermaid
-    end: (})
-    endCaptures:
-      '1':
-        name: keyword.control.mermaid
-  - comment: 'class (class name) ~?(generic type)?~?'
-    match: !regex |-
-      (class)\s+ #class
-      ([\w-]+) # class name
-      (~)? # ~
-      ([\w-]+)? # generic type name
-      (~)? # ~
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: entity.name.type.class.mermaid
-      '3':
-        name: punctuation.definition.typeparameters.begin.mermaid
-      '4':
-        name: storage.type.mermaid
-      '5':
-        name: punctuation.definition.typeparameters.end.mermaid
+        '1':
+          name: punctuation.definition.typeparameters.begin.mermaid
+        '2':
+          name: storage.type.mermaid
+        '3':
+          name: punctuation.definition.typeparameters.end.mermaid
+        '4':
+          name: entity.name.type.class.mermaid
+    - comment: 'class (class name) ~?(generic type)?~? ({)'
+      begin: !regex |-
+        (class)\s+ #class
+        ([\w-]+) # class name
+        (~)? # ~
+        ([\w-]+)? # generic type name
+        (~)? # ~
+        \s?({) # begin bracket
+      beginCaptures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: entity.name.type.class.mermaid
+        '3':
+          name: punctuation.definition.typeparameters.begin.mermaid
+        '4':
+          name: storage.type.mermaid
+        '5':
+          name: punctuation.definition.typeparameters.end.mermaid
+        '6':
+          name: keyword.control.mermaid
+      patterns:
+        - match: \%%.*
+          name: comment
+        - comment: '(visibility)?(function)( (function param/generic param)? )(classifier)? (return/generic return)?$'
+          begin: !regex |-
+            \s([\+~#-])? # visibility
+            ([\w-]+) # function name
+            (\() # (
+          beginCaptures:
+            '1':
+              name: keyword.control.mermaid
+            '2':
+              name: entity.name.function.mermaid
+            '3':
+              name: punctuation.parenthesis.open.mermaid
+          patterns:
+            - comment: (TBD)
+              match: !regex |-
+                \s*,?\s*([\w-]+)? # function param
+                (~)? # ~
+                ([\w-]+)? # generic function param
+                (~)? # ~
+                \s?([\w-]+)? # function name
+              captures:
+                '1':
+                  name: storage.type.mermaid
+                '2':
+                  name: punctuation.definition.typeparameters.begin.mermaid
+                '3':
+                  name: storage.type.mermaid
+                '4':
+                  name: punctuation.definition.typeparameters.end.mermaid
+                '5':
+                  name: entity.name.variable.parameter.mermaid
+          end: !regex |-
+            (\)) # )
+            ([*\$])? # classifier
+            \s?([\w-]+)? # return type
+            (~)? # ~
+            ([\w-]+)? # generic return type
+            (~)?$ # ~
+          endCaptures:
+            '1':
+              name: punctuation.parenthesis.closed.mermaid
+            '2':
+              name: keyword.control.mermaid
+            '3':
+              name: storage.type.mermaid
+            '4':
+              name: punctuation.definition.typeparameters.begin.mermaid
+            '5':
+              name: storage.type.mermaid
+            '6':
+              name: punctuation.definition.typeparameters.end.mermaid
+        - comment: '(visibility)?(datatype/generic data type) (attribute name)$'
+          match: !regex |-
+            \s([\+~#-])? # visibility
+            ([\w-]+) # datatype
+            (~)? # ~
+            ([\w-]+)? # datatype
+            (~)? # ~
+            \s([\w-]+)?$ # attribute name
+          captures:
+            '1':
+              name: keyword.control.mermaid
+            '2':
+              name: storage.type.mermaid
+            '3':
+              name: punctuation.definition.typeparameters.begin.mermaid
+            '4':
+              name: storage.type.mermaid
+            '5':
+              name: punctuation.definition.typeparameters.end.mermaid
+            '6':
+              name: entity.name.variable.field.mermaid
+        - comment: '<<(Annotation)>> (class name)'
+          match: !regex |-
+            (<<) # <<
+            ([\w-]+) # annotation
+            (>>) # >>
+            \s?([\w-]+)? # class name
+          captures:
+            '1':
+              name: punctuation.definition.typeparameters.begin.mermaid
+            '2':
+              name: storage.type.mermaid
+            '3':
+              name: punctuation.definition.typeparameters.end.mermaid
+            '4':
+              name: entity.name.type.class.mermaid
+      end: (})
+      endCaptures:
+        '1':
+          name: keyword.control.mermaid
+    - comment: 'class (class name) ~?(generic type)?~?'
+      match: !regex |-
+        (class)\s+ #class
+        ([\w-]+) # class name
+        (~)? # ~
+        ([\w-]+)? # generic type name
+        (~)? # ~
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: entity.name.type.class.mermaid
+        '3':
+          name: punctuation.definition.typeparameters.begin.mermaid
+        '4':
+          name: storage.type.mermaid
+        '5':
+          name: punctuation.definition.typeparameters.end.mermaid
 
   end: (^|\G)(?=\s*[`~]{3,}\s*$)

--- a/syntaxes/diagrams/erDiagram.yaml
+++ b/syntaxes/diagrams/erDiagram.yaml
@@ -4,57 +4,56 @@
     '1':
       name: keyword.control.mermaid
   patterns:
-  - match: \%%.*
-    name: comment
-  - comment: '(entity)'
-    match: ^\s*([\w-]+)$
-    name: variable
-  - comment: '(entity) {'
-    begin: !regex |-
+    - match: \%%.*
+      name: comment
+    - comment: '(entity)'
+      match: ^\s*([\w-]+)$
+      name: variable
+    - comment: '(entity) {'
+      begin: !regex |-
         \s+([\w-]+) # entity name
         \s+({) # {
-    beginCaptures:
-      '1':
-        name: variable
-      '2':
-        name: keyword.control.mermaid
-    patterns:
-    - comment: '(type) (name) (PK|FK)? ("comment")?'
-      match: !regex |-
-          \s*([\w-]+)\s+ # type
-          ([\w-]+)\s+ # name
-          (PK|FK)?\s* # key?
-          ("["\($&%\^/#.,?!;:*+=<>\'\\\-\w\s]*")?\s* # comment?
-      captures:
+      beginCaptures:
         '1':
-          name: storage.type.mermaid
-        '2':
           name: variable
-        '3':
+        '2':
           name: keyword.control.mermaid
-        '4':
-          name: string
-    end: (})
-    endCaptures:
-      '1':
-        name: keyword.control.mermaid
-  - comment: '(entity) (relationship) (entity) : (label)'
-    match: !regex |-
+      patterns:
+        - comment: '(type) (name) (PK|FK)? ("comment")?'
+          match: !regex |-
+            \s*([\w-]+)\s+ # type
+            ([\w-]+)\s+ # name
+            (PK|FK)?\s* # key?
+            ("["\($&%\^/#.,?!;:*+=<>\'\\\-\w\s]*")?\s* # comment?
+          captures:
+            '1':
+              name: storage.type.mermaid
+            '2':
+              name: variable
+            '3':
+              name: keyword.control.mermaid
+            '4':
+              name: string
+      end: (})
+      endCaptures:
+        '1':
+          name: keyword.control.mermaid
+    - comment: '(entity) (relationship) (entity) : (label)'
+      match: !regex |-
         \s*([\w-]+)\s+ # entity
         ((?:\|o|\|\||}o|}\|)(?:..|--)(?:o\||\|\||o{|\|{))\s+ # relationship
         ([\w-]+)\s+ # entity
         (:)\s+ # :
         ((?:"[\w\s]*")|(?:[\w-]+)) # label
-    captures:
-      '1':
-        name: variable
-      '2':
-        name: keyword.control.mermaid
-      '3':
-        name: variable
-      '4':
-        name: keyword.control.mermaid
-      '5':
-        name: string
+      captures:
+        '1':
+          name: variable
+        '2':
+          name: keyword.control.mermaid
+        '3':
+          name: variable
+        '4':
+          name: keyword.control.mermaid
+        '5':
+          name: string
   end: (^|\G)(?=\s*[`~]{3,}\s*$)
-  

--- a/syntaxes/diagrams/ganttDiagram.yaml
+++ b/syntaxes/diagrams/ganttDiagram.yaml
@@ -4,52 +4,52 @@
     '1':
       name: keyword.control.mermaid
   patterns:
-  - match: \%%.*
-    name: comment
-  - match: !regex |-
-      (dateFormat)\s+ # dateFormat
-      ([\w-]+) # format
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: entity.name.function.mermaid
-  - match: !regex |-
-      (axisFormat)\s+ # axisFormat
-      ([\w\%/-]+) # format
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: entity.name.function.mermaid
-  - match: !regex |-
-      (title)\s+ # title
-      (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: string
-  - match: !regex |-
-      (section)\s+ # section
-      (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: string
-  - begin: !regex |-
-      \s(.*) # Task Text
-      (:) # :
-    beginCaptures:
-      '1':
-        name: string
-      '2':
-        name: keyword.control.mermaid
-    patterns:
-    - match: (crit|done|active|after)
-      name: entity.name.function.mermaid
     - match: \%%.*
       name: comment
-    end: "$"
+    - match: !regex |-
+        (dateFormat)\s+ # dateFormat
+        ([\w-]+) # format
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: entity.name.function.mermaid
+    - match: !regex |-
+        (axisFormat)\s+ # axisFormat
+        ([\w\%/-]+) # format
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: entity.name.function.mermaid
+    - match: !regex |-
+        (title)\s+ # title
+        (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: string
+    - match: !regex |-
+        (section)\s+ # section
+        (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: string
+    - begin: !regex |-
+        \s(.*) # Task Text
+        (:) # :
+      beginCaptures:
+        '1':
+          name: string
+        '2':
+          name: keyword.control.mermaid
+      patterns:
+        - match: (crit|done|active|after)
+          name: entity.name.function.mermaid
+        - match: \%%.*
+          name: comment
+      end: '$'
   end: (^|\G)(?=\s*[`~]{3,}\s*$)

--- a/syntaxes/diagrams/gitGraph.yaml
+++ b/syntaxes/diagrams/gitGraph.yaml
@@ -4,106 +4,106 @@
     '1':
       name: keyword.control.mermaid
   patterns:
-  - match: \%%.*
-    name: comment
-  - comment: commit
-    begin: !regex |-
-      \s*(commit) # commit
-    beginCaptures:
-      '1':
-        name: keyword.control.mermaid
-    patterns:
-    - comment: '(id)(:) ("id")'
+    - match: \%%.*
+      name: comment
+    - comment: commit
+      begin: !regex |-
+        \s*(commit) # commit
+      beginCaptures:
+        '1':
+          name: keyword.control.mermaid
+      patterns:
+        - comment: '(id)(:) ("id")'
+          match: !regex |-
+            \s*(id) # id
+            (:) # :
+            \s?("[^"\n]*") # text
+          captures:
+            '1':
+              name: keyword.control.mermaid
+            '2':
+              name: keyword.control.mermaid
+            '3':
+              name: string
+        - comment: '(type)(:) (COMMIT_TYPE)'
+          match: !regex |-
+            \s*(type) # type
+            (:) # :
+            \s?(NORMAL|REVERSE|HIGHLIGHT) # commit_type
+          captures:
+            '1':
+              name: keyword.control.mermaid
+            '2':
+              name: keyword.control.mermaid
+            '3':
+              name: entity.name.function.mermaid
+        - comment: '(tag)(:) ("tag")'
+          match: !regex |-
+            \s*(tag) # tag
+            (:) # :
+            \s?("[\($&%\^/#.,?!;:*+=<>\'\\\-\w\s]*") # text
+          captures:
+            '1':
+              name: keyword.control.mermaid
+            '2':
+              name: keyword.control.mermaid
+            '3':
+              name: string
+      end: '$'
+    - comment: '(checkout) (branch-name)'
       match: !regex |-
-        \s*(id) # id
-        (:) # :
-        \s?("[^"\n]*") # text
+        \s*(checkout) # checkout
+        \s*([^\s"]*) # branch-name
       captures:
         '1':
           name: keyword.control.mermaid
         '2':
+          name: variable
+    - comment: '(branch) (branch-name) (order)?(:) (number)'
+      match: !regex |-
+        \s*(branch) # branch
+        \s*([^\s"]*) # branch-name
+        \s*(?:(order)(:)\s?(\d+))? # (order)(:) (number)
+      captures:
+        '1':
           name: keyword.control.mermaid
+        '2':
+          name: variable
         '3':
+          name: keyword.control.mermaid
+        '4':
+          name: keyword.control.mermaid
+        '5':
+          name: constant.numeric.decimal.mermaid
+    - comment: '(merge) (branch-name) (tag: "tag-name")?'
+      match: !regex |-
+        \s*(merge) # merge
+        \s*([^\s"]*) # branch-name
+        \s*(?:(tag)(:)\s?("[^"\n]*"))? # (tag: "tag-name")?
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: variable
+        '3':
+          name: keyword.control.mermaid
+        '4':
+          name: keyword.control.mermaid
+        '5':
           name: string
-    - comment: '(type)(:) (COMMIT_TYPE)'
+    - comment: '(cherry-pick) (id)(:)("commit-id")'
       match: !regex |-
-        \s*(type) # type
+        \s*(cherry-pick) # cherry-pick
+        \s+(id) # id
         (:) # :
-        \s?(NORMAL|REVERSE|HIGHLIGHT) # commit_type
+        \s*("[^"\n]*") # "commit-id"
       captures:
         '1':
           name: keyword.control.mermaid
         '2':
           name: keyword.control.mermaid
         '3':
-          name: entity.name.function.mermaid
-    - comment: '(tag)(:) ("tag")'
-      match: !regex |-
-        \s*(tag) # tag
-        (:) # :
-        \s?("[\($&%\^/#.,?!;:*+=<>\'\\\-\w\s]*") # text
-      captures:
-        '1':
           name: keyword.control.mermaid
-        '2':
-          name: keyword.control.mermaid
-        '3':
+        '4':
           name: string
-    end: "$"
-  - comment: '(checkout) (branch-name)'
-    match: !regex |-
-      \s*(checkout) # checkout
-      \s*([^\s"]*) # branch-name
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: variable
-  - comment: '(branch) (branch-name) (order)?(:) (number)'
-    match: !regex |-
-      \s*(branch) # branch
-      \s*([^\s"]*) # branch-name
-      \s*(?:(order)(:)\s?(\d+))? # (order)(:) (number)
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: variable
-      '3':
-        name: keyword.control.mermaid
-      '4':
-        name: keyword.control.mermaid
-      '5':
-        name: constant.numeric.decimal.mermaid
-  - comment: '(merge) (branch-name) (tag: "tag-name")?'
-    match: !regex |-
-      \s*(merge) # merge
-      \s*([^\s"]*) # branch-name
-      \s*(?:(tag)(:)\s?("[^"\n]*"))? # (tag: "tag-name")?
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: variable
-      '3':
-        name: keyword.control.mermaid
-      '4':
-        name: keyword.control.mermaid
-      '5':
-        name: string
-  - comment: '(cherry-pick) (id)(:)("commit-id")'
-    match: !regex |-
-      \s*(cherry-pick) # cherry-pick
-      \s+(id) # id
-      (:) # :
-      \s*("[^"\n]*") # "commit-id"
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: keyword.control.mermaid
-      '3':
-        name: keyword.control.mermaid
-      '4':
-        name: string
   end: (^|\G)(?=\s*[`~]{3,}\s*$)

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -6,89 +6,73 @@
     '2':
       name: entity.name.function.mermaid
   patterns:
-  - match: \%%.*
-    name: comment
-  - match: \b(subgraph)\s+([A-Za-z\ 0-9]+)
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: entity.name.function.mermaid
-    name: meta.function.mermaid
-  - match: \b(end|RB|BT|RL|TD|LR)\b
-    name: keyword.control.mermaid
-  - comment: '(Entity From)(Graph Link)'
-    begin: !regex |-
-      (\b[-\w]+\b\s*) # Entity From
-      (-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?|<-->) # Graph Link
-    beginCaptures:
-      '1':
-        name: variable
-      '2':
-        name: keyword.control.mermaid
-    patterns:
     - match: \%%.*
       name: comment
-    - comment: '(Graph Link Text)?(Graph Link)(Entity To)?(Edge/Shape)?(Text)?(Edge/Shape)?'
-      match: !regex |-
-        (\s*(?:"[^"]+")|(?:[\($&%\^/#.,?!;:*+<>_\'\\\w\s]*))? # Graph Link Text?
-        \s*(-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?|\|) # Graph Link
-        (\s*[-\w]+\b) # Entity To
-        (\[|\(+|\>|\{)? # Edge/Shape?
-        (\s*[-\w]+\b)? # Text
-        (\]|\)+|\})? # Edge/shape
+    - match: \b(subgraph)\s+([A-Za-z\ 0-9]+)
       captures:
         '1':
-          name: string
+          name: keyword.control.mermaid
         '2':
-          name: keyword.control.mermaid
-        '3':
-          name: variable
-        '4':
-          name: keyword.control.mermaid
-        '5':
-          name: string
-        '6':
-          name: keyword.control.mermaid
-    - comment: '(Entity To)(Edge/Shape)?(Text)?(Edge/Shape)?'
-      match: !regex |-
-        (\s*[-\w]+\b) # Entity To
-        (\[|\(+|\>|\{)? # Edge/Shape?
-        (\s*[-\w]+\b)? # Text?
-        (\]|\)+|\})? # Edge/Shape?
-      captures:
+          name: entity.name.function.mermaid
+      name: meta.function.mermaid
+    - match: \b(end|RB|BT|RL|TD|LR)\b
+      name: keyword.control.mermaid
+    - comment: '(Entity From)(Graph Link)'
+      begin: !regex |-
+        (\b[-\w]+\b\s*) # Entity From
+        (-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?|<-->) # Graph Link
+      beginCaptures:
         '1':
           name: variable
         '2':
           name: keyword.control.mermaid
-        '3':
-          name: string
-        '4':
-          name: keyword.control.mermaid
-    end: "$"
-  - comment: '(Entity)(Edge/Shape)(Text)(Edge/Shape)'
-    begin: !regex |-
-      (\b[-\w]+\b\s*) # Entity
-      (\[|\(+|\>|\{|\(\() # Edge/Shape
-      (\s*(?:"[^"]+")|(?:[$&%\^/#.,?!;:*+<>_\'\\\w\s]*)) # Text
-      (\]|\)+|\}|\)\)) # Edge/Shape
-    beginCaptures:
-      '1':
-        name: variable
-      '2':
-        name: keyword.control.mermaid
-      '3':
-        name: string
-      '4':
-        name: keyword.control.mermaid
-    patterns:
+      patterns:
+        - match: \%%.*
+          name: comment
+        - comment: '(Graph Link Text)?(Graph Link)(Entity To)?(Edge/Shape)?(Text)?(Edge/Shape)?'
+          match: !regex |-
+            (\s*(?:"[^"]+")|(?:[\($&%\^/#.,?!;:*+<>_\'\\\w\s]*))? # Graph Link Text?
+            \s*(-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?|\|) # Graph Link
+            (\s*[-\w]+\b) # Entity To
+            (\[|\(+|\>|\{)? # Edge/Shape?
+            (\s*[-\w]+\b)? # Text
+            (\]|\)+|\})? # Edge/shape
+          captures:
+            '1':
+              name: string
+            '2':
+              name: keyword.control.mermaid
+            '3':
+              name: variable
+            '4':
+              name: keyword.control.mermaid
+            '5':
+              name: string
+            '6':
+              name: keyword.control.mermaid
+        - comment: '(Entity To)(Edge/Shape)?(Text)?(Edge/Shape)?'
+          match: !regex |-
+            (\s*[-\w]+\b) # Entity To
+            (\[|\(+|\>|\{)? # Edge/Shape?
+            (\s*[-\w]+\b)? # Text?
+            (\]|\)+|\})? # Edge/Shape?
+          captures:
+            '1':
+              name: variable
+            '2':
+              name: keyword.control.mermaid
+            '3':
+              name: string
+            '4':
+              name: keyword.control.mermaid
+      end: '$'
     - comment: '(Entity)(Edge/Shape)(Text)(Edge/Shape)'
-      match: !regex |-
-        (\s*\b[-\w]+\b\s*) # Entity
-        (\[|\(+|\>|\{) # Edge/Shape
-        (\s*["\($&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # Text
-        (\]|\)+|\}) # Edge/Shape
-      captures:
+      begin: !regex |-
+        (\b[-\w]+\b\s*) # Entity
+        (\[|\(+|\>|\{|\(\() # Edge/Shape
+        (\s*(?:"[^"]+")|(?:[$&%\^/#.,?!;:*+<>_\'\\\w\s]*)) # Text
+        (\]|\)+|\}|\)\)) # Edge/Shape
+      beginCaptures:
         '1':
           name: variable
         '2':
@@ -97,70 +81,86 @@
           name: string
         '4':
           name: keyword.control.mermaid
-    - comment: '(Graph Link)(Graph Link Text)(Graph Link)(Entity)(Edge/Shape)(Text)(Edge/Shape)'
+      patterns:
+        - comment: '(Entity)(Edge/Shape)(Text)(Edge/Shape)'
+          match: !regex |-
+            (\s*\b[-\w]+\b\s*) # Entity
+            (\[|\(+|\>|\{) # Edge/Shape
+            (\s*["\($&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # Text
+            (\]|\)+|\}) # Edge/Shape
+          captures:
+            '1':
+              name: variable
+            '2':
+              name: keyword.control.mermaid
+            '3':
+              name: string
+            '4':
+              name: keyword.control.mermaid
+        - comment: '(Graph Link)(Graph Link Text)(Graph Link)(Entity)(Edge/Shape)(Text)(Edge/Shape)'
+          match: !regex |-
+            (\s*-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?) # Graph Link
+            (\s*[-\w\s]+\b)? # Graph Link Text
+            (-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?|\|)? # Graph Link
+            (\s*\b[-\w]+\b\s*) # Entity
+            (\[|\(+|\>|\{) # Edge/Shape
+            (\s*["\($&%\^/#.,?!;:*+=<>\'\\\-\w\s]*)? # Text
+            (\]|\)+|\}) # Edge/Shape
+          captures:
+            '1':
+              name: keyword.control.mermaid
+            '2':
+              name: string
+            '3':
+              name: keyword.control.mermaid
+            '4':
+              name: variable
+            '5':
+              name: keyword.control.mermaid
+            '6':
+              name: string
+            '7':
+              name: keyword.control.mermaid
+      end: '$'
+    - match: (\b[-\w]+\b\s*)
+      name: variable
+    - comment: '(Class)(Node(s))(ClassName)'
       match: !regex |-
-        (\s*-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?) # Graph Link
-        (\s*[-\w\s]+\b)? # Graph Link Text
-        (-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?|\|)? # Graph Link
-        (\s*\b[-\w]+\b\s*) # Entity
-        (\[|\(+|\>|\{) # Edge/Shape
-        (\s*["\($&%\^/#.,?!;:*+=<>\'\\\-\w\s]*)? # Text
-        (\]|\)+|\}) # Edge/Shape
+        \s*(class) # class
+        \s+(\b[-,\w]+) # Node(s)
+        \s+(\b\w+\b) # ClassName
       captures:
         '1':
           name: keyword.control.mermaid
         '2':
-          name: string
-        '3':
-          name: keyword.control.mermaid
-        '4':
           name: variable
-        '5':
-          name: keyword.control.mermaid
-        '6':
+        '3':
           name: string
-        '7':
+    - comment: '(ClassDef)(ClassName)(Styles)'
+      match: !regex |-
+        \s*(classDef) # classDef
+        \s+(\b\w+\b) # ClassName
+        \s+(\b[-,:;#\w]+) # Styles
+      captures:
+        '1':
           name: keyword.control.mermaid
-    end: "$"
-  - match: (\b[-\w]+\b\s*)
-    name: variable
-  - comment: '(Class)(Node(s))(ClassName)'
-    match: !regex |-
-      \s*(class) # class
-      \s+(\b[-,\w]+) # Node(s)
-      \s+(\b\w+\b) # ClassName
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: variable
-      '3':
-        name: string
-  - comment: '(ClassDef)(ClassName)(Styles)'
-    match: !regex |-
-      \s*(classDef) # classDef
-      \s+(\b\w+\b) # ClassName
-      \s+(\b[-,:;#\w]+) # Styles
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: variable
-      '3':
-        name: string
-  - comment: '(Click)(Entity)(Link)?(Tooltip)'
-    match: !regex |-
-      \s*(click) # Click
-      \s+(\b[-\w]+\b\s*) # Entity
-      (\b\w+\b)? # Link/callback?
-      \s("*.*") # Tooltip
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: variable
-      '3':
-        name: variable
-      '4':
-        name: string
+        '2':
+          name: variable
+        '3':
+          name: string
+    - comment: '(Click)(Entity)(Link)?(Tooltip)'
+      match: !regex |-
+        \s*(click) # Click
+        \s+(\b[-\w]+\b\s*) # Entity
+        (\b\w+\b)? # Link/callback?
+        \s("*.*") # Tooltip
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: variable
+        '3':
+          name: variable
+        '4':
+          name: string
   end: (^|\G)(?=\s*[`~]{3,}\s*$)

--- a/syntaxes/diagrams/pieChart.yaml
+++ b/syntaxes/diagrams/pieChart.yaml
@@ -4,26 +4,26 @@
     '1':
       name: keyword.control.mermaid
   patterns:
-  - match: \%%.*
-    name: comment
-  - match: !regex |-
-      (title)\s+ # title
-      (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: string
-  - begin: !regex |-
-      \s(.*) # DataKey Text
-      (:) # :
-    beginCaptures:
-      '1':
-        name: string
-      '2':
-        name: keyword.control.mermaid
-    patterns:
     - match: \%%.*
       name: comment
-    end: "$"
+    - match: !regex |-
+        (title)\s+ # title
+        (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: string
+    - begin: !regex |-
+        \s(.*) # DataKey Text
+        (:) # :
+      beginCaptures:
+        '1':
+          name: string
+        '2':
+          name: keyword.control.mermaid
+      patterns:
+        - match: \%%.*
+          name: comment
+      end: '$'
   end: (^|\G)(?=\s*[`~]{3,}\s*$)

--- a/syntaxes/diagrams/stateDiagram.yaml
+++ b/syntaxes/diagrams/stateDiagram.yaml
@@ -4,86 +4,26 @@
     '1':
       name: keyword.control.mermaid
   patterns:
-  - match: \%%.*
-    name: comment
-  - comment: '}'
-    match: \s+(})\s+
-    captures:
-      '1':
-        name: keyword.control.mermaid
-  - comment: '--'
-    match: \s+(--)\s+
-    captures:
-      '1':
-        name: keyword.control.mermaid
-  - comment: '(state)'
-    match: ^\s*([\w-]+)$
-    name: variable
-  - comment: '(state) : (description)'
-    match: !regex |-
-      ([\w-]+) # state name
-      \s+(:) # :
-      \s+(\s*[-\w\s]+\b) # description
-    captures:
-      '1':
-        name: variable
-      '2':
-        name: keyword.control.mermaid
-      '3':
-        name: string
-  - comment: 'state'
-    begin: !regex |-
-      (state) # state
-    beginCaptures:
-      '1':
-        name: keyword.control.mermaid
-    patterns:
-    - comment: '"(description)" as (state)'
-      match: !regex |-
-        \s+("[-\w\s]+\b") # description
-        \s+(as) # as
-        \s+([\w-]+) # state name
+    - match: \%%.*
+      name: comment
+    - comment: '}'
+      match: \s+(})\s+
       captures:
         '1':
-          name: string
-        '2':
           name: keyword.control.mermaid
-        '3':
-          name: variable
-    - comment: '(state name) {'
-      match: !regex |-
-        \s+([\w-]+) # state name
-        \s+({) # {
+    - comment: '--'
+      match: \s+(--)\s+
       captures:
         '1':
-          name: variable
-        '2':
           name: keyword.control.mermaid
-    - comment: '(state name) <<fork|join>>'
+    - comment: '(state)'
+      match: ^\s*([\w-]+)$
+      name: variable
+    - comment: '(state) : (description)'
       match: !regex |-
-        \s+([\w-]+) # state name
-        \s+(<<(?:fork|join)>>) # <<fork|join>>
-      captures:
-        '1':
-          name: variable
-        '2':
-          name: keyword.control.mermaid
-    end: "$"
-  - comment: '(state) -->'
-    begin: !regex |-
-      ([\w-]+) # state name
-      \s+(-->) # -->
-    beginCaptures:
-      '1':
-        name: variable
-      '2':
-        name: keyword.control.mermaid
-    patterns:
-    - comment: '(state) (:)? (transition text)?'
-      match: !regex |-
-        \s+([\w-]+) # state name
-        \s*(:)? # :
-        \s*(\s*[-\w\s]+\b)? # transition text
+        ([\w-]+) # state name
+        \s+(:) # :
+        \s+(\s*[-\w\s]+\b) # description
       captures:
         '1':
           name: variable
@@ -91,9 +31,84 @@
           name: keyword.control.mermaid
         '3':
           name: string
-    - comment: '[*] (:)? (transition text)?'
+    - comment: 'state'
+      begin: !regex |-
+        (state) # state
+      beginCaptures:
+        '1':
+          name: keyword.control.mermaid
+      patterns:
+        - comment: '"(description)" as (state)'
+          match: !regex |-
+            \s+("[-\w\s]+\b") # description
+            \s+(as) # as
+            \s+([\w-]+) # state name
+          captures:
+            '1':
+              name: string
+            '2':
+              name: keyword.control.mermaid
+            '3':
+              name: variable
+        - comment: '(state name) {'
+          match: !regex |-
+            \s+([\w-]+) # state name
+            \s+({) # {
+          captures:
+            '1':
+              name: variable
+            '2':
+              name: keyword.control.mermaid
+        - comment: '(state name) <<fork|join>>'
+          match: !regex |-
+            \s+([\w-]+) # state name
+            \s+(<<(?:fork|join)>>) # <<fork|join>>
+          captures:
+            '1':
+              name: variable
+            '2':
+              name: keyword.control.mermaid
+      end: '$'
+    - comment: '(state) -->'
+      begin: !regex |-
+        ([\w-]+) # state name
+        \s+(-->) # -->
+      beginCaptures:
+        '1':
+          name: variable
+        '2':
+          name: keyword.control.mermaid
+      patterns:
+        - comment: '(state) (:)? (transition text)?'
+          match: !regex |-
+            \s+([\w-]+) # state name
+            \s*(:)? # :
+            \s*(\s*[-\w\s]+\b)? # transition text
+          captures:
+            '1':
+              name: variable
+            '2':
+              name: keyword.control.mermaid
+            '3':
+              name: string
+        - comment: '[*] (:)? (transition text)?'
+          match: !regex |-
+            (\[\*\]) # [*]
+            \s*(:)? # :
+            \s*(\s*[-\w\s]+\b)? # transition text
+          captures:
+            '1':
+              name: keyword.control.mermaid
+            '2':
+              name: keyword.control.mermaid
+            '3':
+              name: string
+      end: $
+    - comment: '[*] --> (state) (:)? (transition text)?'
       match: !regex |-
         (\[\*\]) # [*]
+        \s+(-->) # -->
+        \s+([\w-]+) # state name
         \s*(:)? # :
         \s*(\s*[-\w\s]+\b)? # transition text
       captures:
@@ -102,54 +117,39 @@
         '2':
           name: keyword.control.mermaid
         '3':
+          name: variable
+        '4':
+          name: keyword.control.mermaid
+        '5':
           name: string
-    end: $
-  - comment: '[*] --> (state) (:)? (transition text)?'
-    match: !regex |-
-      (\[\*\]) # [*]
-      \s+(-->) # -->
-      \s+([\w-]+) # state name
-      \s*(:)? # :
-      \s*(\s*[-\w\s]+\b)? # transition text
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: keyword.control.mermaid
-      '3':
-        name: variable
-      '4':
-        name: keyword.control.mermaid
-      '5':
-        name: string
-  - comment: 'note left|right of (state name)'
-    match: !regex |-
-      (note (?:left|right) of) # note left|right of
-      \s+([\w-]+) # state name
-      \s+(:) # :
-      \s*(\s*[-\w\s]+\b) # note text
-    captures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: variable
-      '3':
-        name: keyword.control.mermaid
-      '4':
-        name: string
-  - comment: 'note left|right of (state name) (note text) end note'
-    begin: !regex |-
-      (note (?:left|right) of) # note left|right of
-      \s+([\w-]+)(.|\n) # state name
-    beginCaptures:
-      '1':
-        name: keyword.control.mermaid
-      '2':
-        name: variable
-    contentName: string
-    end: !regex |-
-      (end note)
-    endCaptures:
-      '1':
-        name: keyword.control.mermaid
+    - comment: 'note left|right of (state name)'
+      match: !regex |-
+        (note (?:left|right) of) # note left|right of
+        \s+([\w-]+) # state name
+        \s+(:) # :
+        \s*(\s*[-\w\s]+\b) # note text
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: variable
+        '3':
+          name: keyword.control.mermaid
+        '4':
+          name: string
+    - comment: 'note left|right of (state name) (note text) end note'
+      begin: !regex |-
+        (note (?:left|right) of) # note left|right of
+        \s+([\w-]+)(.|\n) # state name
+      beginCaptures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: variable
+      contentName: string
+      end: !regex |-
+        (end note)
+      endCaptures:
+        '1':
+          name: keyword.control.mermaid
   end: (^|\G)(?=\s*[`~]{3,}\s*$)


### PR DESCRIPTION
Add prettier validation to all `markdown`, `js`, and `yaml` files. `mermaid` files (used for tests) are not supported by prettier.