### PR TITLE
Fix State Diagram Note/Transition Text

### DIFF
--- a/syntaxes/diagrams/stateDiagram.yaml
+++ b/syntaxes/diagrams/stateDiagram.yaml
@@ -1,5 +1,5 @@
 - comment: State Diagram
-  begin: ^\s*(stateDiagram)
+  begin: ^\s*(stateDiagram(?:-v2)?)
   beginCaptures:
     '1':
       name: keyword.control.mermaid

--- a/syntaxes/diagrams/stateDiagram.yaml
+++ b/syntaxes/diagrams/stateDiagram.yaml
@@ -83,7 +83,7 @@
           match: !regex |-
             \s+([\w-]+) # state name
             \s*(:)? # :
-            \s*(\s*[-\w\s]+\b)? # transition text
+            \s*([^\n:]+)? # transition text
           captures:
             '1':
               name: variable
@@ -95,7 +95,7 @@
           match: !regex |-
             (\[\*\]) # [*]
             \s*(:)? # :
-            \s*(\s*[-\w\s]+\b)? # transition text
+            \s*([^\n:]+)? # transition text
           captures:
             '1':
               name: keyword.control.mermaid
@@ -110,7 +110,7 @@
         \s+(-->) # -->
         \s+([\w-]+) # state name
         \s*(:)? # :
-        \s*(\s*[-\w\s]+\b)? # transition text
+        \s*([^\n:]+)? # transition text
       captures:
         '1':
           name: keyword.control.mermaid

--- a/syntaxes/diagrams/stateDiagram.yaml
+++ b/syntaxes/diagrams/stateDiagram.yaml
@@ -127,7 +127,7 @@
         (note (?:left|right) of) # note left|right of
         \s+([\w-]+) # state name
         \s+(:) # :
-        \s*(\s*[-\w\s]+\b) # note text
+        \s*([^\n:]+) # note text
       captures:
         '1':
           name: keyword.control.mermaid

--- a/tests/diagrams/state-v2.test.mermaid
+++ b/tests/diagrams/state-v2.test.mermaid
@@ -1,0 +1,10 @@
+%% SYNTAX TEST "source.mermaid" "state diagram v2 test"
+
+stateDiagram-v2
+%% <--------------- keyword.control.mermaid
+  s1
+%%^^ variable
+  s1 --> s2
+%%^^ variable
+%%   ^^^ keyword.control.mermaid
+%%       ^^ variable

--- a/tests/diagrams/state.test.mermaid
+++ b/tests/diagrams/state.test.mermaid
@@ -10,7 +10,6 @@ stateDiagram
 %%^^ variable
 %%   ^ keyword.control.mermaid
 %%     ^^^^^^^^^^^^^^^^^^^^^^ string
-
   s1 --> s2
 %%^^ variable
 %%   ^^^ keyword.control.mermaid
@@ -116,12 +115,12 @@ stateDiagram
 %%    ^^^ keyword.control.mermaid
 %%        ^^^ keyword.control.mermaid
 %%            ^^^^^^^^^^^ variable
-      CapsLockOff --> CapsLockOn : EvCapsLockPressed
+      CapsLockOff --> CapsLockOn : EvCapsLockPressed/moreText
 %%    ^^^^^^^^^^^ variable
 %%                ^^^ keyword.control.mermaid
 %%                    ^^^^^^^^^^ variable
 %%                               ^ keyword.control.mermaid
-%%                                 ^^^^^^^^^^^^^^^^^ string
+%%                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ string
       CapsLockOn --> CapsLockOff : EvCapsLockPressed
 %%    ^^^^^^^^^^ variable
 %%               ^^^ keyword.control.mermaid

--- a/tests/diagrams/state.test.mermaid
+++ b/tests/diagrams/state.test.mermaid
@@ -83,11 +83,11 @@ stateDiagram
 %%  ^^^^^^ string
   end note
 %%^^^^^^^^ keyword.control.mermaid
-  note left of State2 : This is the note to the left.
+  note left of State2 : This is the note to the left./nMore text
 %%^^^^^^^^^^^^ keyword.control.mermaid
 %%             ^^^^^^ variable
 %%                    ^ keyword.control.mermaid
-%%                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
+%%                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
 
   %% concurrency
   state Active {


### PR DESCRIPTION
Fix the highlighting issues in #55.
* Be more flexible in note and transition text. Both should highlight the rest of the line aside from colons(:).
* Add support for v2 diagram name (`stateDiagram-v2`)