### PR TITLE
Add Graph Multiline Text Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.4.2]
+
+- Add graph multiline entity support
+
 ## [v1.4.1]
 
 - Add missing graph entity shapes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,47 +1,49 @@
-## Change Log
+# Change Log
 
-### [v0.0.1]
+## [v1.4.1]
 
-- Initial release with flowchart/graph and sequence diagram support
+- Add missing graph entity shapes
 
-### [v0.0.2]
+## [v1.4.0]
 
-- Add support for complex graph cases
-- Add Mermaid language and support for .mmd files
+- Add git graph support
 
-### [v1.0.0]
+## [v1.3.4]
 
-- Added gantt support, completing support for all 3 graph types
+- Fix sequence diagram title whitespace
+- Fix sequence diagram actor/participant whitespace
 
-### [v1.0.1]
+## [v1.3.3]
 
-- Allow more punctuation in graph and gantt text
+- Add sequence diagram actor support
 
-### [v1.0.2]
+## [v1.3.2]
 
-- Add pie chart support
+- Add graph diagram double arrow support
+- Add class diagram multiple parameter support
 
-### [v1.0.3]
+## [v1.3.1]
 
-- Fix sequence diagram participant label highlighting
+- Add classDiagram reversed arrow support
 
-### [v1.0.4]
+## [v1.3.0]
 
-- Fix sequence diagram entity text highlighting
+- Add entity relationship diagram support
 
-### [v1.0.5]
+## [v1.2.4]
 
-- Add basic flowchart support
+- Add ADO syntax support
 
-### [v1.1.0]
+## [v1.2.3]
 
-- Add class diagram support
+- Fix bug preventing .mmd files from being properly highlighted
+- Add support in graphs for nodes with id only
 
-### [v1.2.0]
+## [v1.2.2]
 
-- Add state diagram support
+- Fix bug in new prepublish build step causing extension to break
 
-### [v1.2.1]
+## [v1.2.1]
 
 - Update sequence diagram support with:
   - Async arrows
@@ -49,45 +51,43 @@
   - Par blocks
   - Rect (color) blocks
 
-### [v1.2.2]
+## [v1.2.0]
 
-- Fix bug in new prepublish build step causing extension to break
+- Add state diagram support
 
-### [v1.2.3]
+## [v1.1.0]
 
-- Fix bug preventing .mmd files from being properly highlighted
-- Add support in graphs for nodes with id only
+- Add class diagram support
 
-### [v1.2.4]
+## [v1.0.5]
 
-- Add ADO syntax support
+- Add basic flowchart support
 
-### [v1.3.0]
+## [v1.0.4]
 
-- Add entity relationship diagram support
+- Fix sequence diagram entity text highlighting
 
-### [v1.3.1]
+## [v1.0.3]
 
-- Add classDiagram reversed arrow support
+- Fix sequence diagram participant label highlighting
 
-### [v1.3.2]
+## [v1.0.2]
 
-- Add graph diagram double arrow support
-- Add class diagram multiple parameter support
+- Add pie chart support
 
-### [v1.3.3]
+## [v1.0.1]
 
-- Add sequence diagram actor support
+- Allow more punctuation in graph and gantt text
 
-### [v1.3.4]
+## [v1.0.0]
 
-- Fix sequence diagram title whitespace
-- Fix sequence diagram actor/participant whitespace
+- Added gantt support, completing support for all 3 graph types
 
-### [v1.4.0]
+## [v0.0.2]
 
-- Add git graph support
+- Add support for complex graph cases
+- Add Mermaid language and support for .mmd files
 
-### [v1.4.1]
+## [v0.0.1]
 
-- Add missing graph entity shapes
+- Initial release with flowchart/graph and sequence diagram support

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "mermaid-markdown-syntax-highlighting",
 	"displayName": "Mermaid Markdown Syntax Highlighting",
 	"description": "Markdown syntax support for the Mermaid charting language",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"publisher": "bpruitt-goddard",
 	"license": "MIT",
 	"engines": {

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -17,61 +17,10 @@
       name: meta.function.mermaid
     - match: \b(end|RB|BT|RL|TD|LR)\b
       name: keyword.control.mermaid
-    - comment: '(Entity From)(Graph Link)'
-      begin: !regex |-
-        (\b[-\w]+\b\s*) # Entity From
-        (-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?|<-->) # Graph Link
-      beginCaptures:
-        '1':
-          name: variable
-        '2':
-          name: keyword.control.mermaid
-      patterns:
-        - match: \%%.*
-          name: comment
-        - comment: '(Graph Link Text)?(Graph Link)(Entity To)?(Edge/Shape)?(Text)?(Edge/Shape)?'
-          match: !regex |-
-            (\s*(?:"[^"]+")|(?:[\($&%\^/#.,?!;:*+<>_\'\\\w\s]*))? # Graph Link Text?
-            \s*(-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?|\|) # Graph Link
-            (\s*[-\w]+\b) # Entity To
-            (\(\[|\[\[|\[\(|\[|\(+|\>|\{|\(\()? # Edge/Shape?
-            \s*([^\]\)\}\n]+)? # Text
-            (\]\)|\]\]|\)\]|\]|\)+|\}|\)\))? # Edge/shape
-          captures:
-            '1':
-              name: string
-            '2':
-              name: keyword.control.mermaid
-            '3':
-              name: variable
-            '4':
-              name: keyword.control.mermaid
-            '5':
-              name: string
-            '6':
-              name: keyword.control.mermaid
-        - comment: '(Entity To)(Edge/Shape)?(Text)?(Edge/Shape)?'
-          match: !regex |-
-            (\s*[-\w]+\b) # Entity To
-            (\(\[|\[\[|\[\(|\[|\(+|\>|\{|\(\()? # Edge/Shape?
-            \s*([^\]\)\}\n]+)? # Text?
-            (\]\)|\]\]|\)\]|\]|\)+|\}|\)\))? # Edge/Shape?
-          captures:
-            '1':
-              name: variable
-            '2':
-              name: keyword.control.mermaid
-            '3':
-              name: string
-            '4':
-              name: keyword.control.mermaid
-      end: '$'
     - comment: '(Entity)(Edge/Shape)(Text)(Edge/Shape)'
       begin: !regex |-
         (\b[-\w]+\b\s*) # Entity
         (\(\[|\[\[|\[\(|\[|\(+|\>|\{|\(\() # Edge/Shape
-        (\s*(?:"[^"]+")|(?:[$&%\^/#.,?!;:*+<>_\'\\\w\s]*)) # Text
-        (\]\)|\]\]|\)\]|\]|\)+|\}|\)\)) # Edge/Shape
       beginCaptures:
         '1':
           name: variable
@@ -79,50 +28,43 @@
           name: keyword.control.mermaid
         '3':
           name: string
-        '4':
-          name: keyword.control.mermaid
       patterns:
-        - comment: '(Entity)(Edge/Shape)(Text)(Edge/Shape)'
+        - comment: ("multi-line text") 
+          begin: '\s*(")'
+          beginCaptures:
+            '1':
+              name: string
+          patterns:
+            - comment: '(capture inner text between quotes)'
+              begin: !regex |-
+                ([^"]*)
+              beginCaptures:
+                '1':
+                  name: string
+              patterns:
+              # This capture is needed to make the begin capture function
+                - match: '([^"]*)'
+                  captures:
+                    '1':
+                      name: comment
+              end: '(?=")'
+          end: '(")'
+          endCaptures:
+            '1':
+              name: string
+        - comment: single line text
           match: !regex |-
-            (\s*\b[-\w]+\b\s*) # Entity
-            (\(\[|\[\[|\[\(|\[|\(+|\>|\{|\(\() # Edge/Shape
-            (\s*["\($&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # Text
-            (\]\)|\]\]|\)\]|\]|\)+|\}|\)\)) # Edge/Shape
+            \s*([$&%\^/#.,?!;:*+<>_\'\\\w\s]+) # Text
           captures:
             '1':
-              name: variable
-            '2':
-              name: keyword.control.mermaid
-            '3':
               name: string
-            '4':
-              name: keyword.control.mermaid
-        - comment: '(Graph Link)(Graph Link Text)(Graph Link)(Entity)(Edge/Shape)(Text)(Edge/Shape)'
-          match: !regex |-
-            (\s*-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?) # Graph Link
-            (\s*[-\w\s]+\b)? # Graph Link Text
-            (-?-[-\>]\|?|=?=[=\>]|(?:\.-|-\.)-?\>?|\|)? # Graph Link
-            (\s*\b[-\w]+\b\s*) # Entity
-            (\(\[|\[\[|\[\(|\[|\(+|\>|\{|\(\() # Edge/Shape
-            (\s*["\($&%\^/#.,?!;:*+=<>\'\\\-\w\s]*)? # Text
-            (\]\)|\]\]|\)\]|\]|\)+|\}|\)\)) # Edge/Shape
-          captures:
-            '1':
-              name: keyword.control.mermaid
-            '2':
-              name: string
-            '3':
-              name: keyword.control.mermaid
-            '4':
-              name: variable
-            '5':
-              name: keyword.control.mermaid
-            '6':
-              name: string
-            '7':
-              name: keyword.control.mermaid
-      end: '$'
-    - match: (\b[-\w]+\b\s*)
+      end: !regex |-
+        (\]\)|\]\]|\)\]|\]|\)+|\}|\)\)) # Edge/Shape
+      endCaptures:
+        '1':
+          name: keyword.control.mermaid
+    - comment: Entity  
+      match: (\b[-\w]+\b\s*)
       name: variable
     - comment: '(Class)(Node(s))(ClassName)'
       match: !regex |-

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -29,20 +29,20 @@
         '3':
           name: string
       patterns:
-        - comment: ("multi-line text") 
+        - comment: ("multi-line text")
           begin: '\s*(")'
           beginCaptures:
             '1':
               name: string
           patterns:
-            - comment: '(capture inner text between quotes)'
+            - comment: capture inner text between quotes
               begin: !regex |-
                 ([^"]*)
               beginCaptures:
                 '1':
                   name: string
               patterns:
-              # This capture is needed to make the begin capture function
+                # This capture is needed to make the begin capture function
                 - match: '([^"]*)'
                   captures:
                     '1':
@@ -52,7 +52,7 @@
           endCaptures:
             '1':
               name: string
-        - comment: single line text
+        - comment: (single line text)
           match: !regex |-
             \s*([$&%\^/#.,?!;:*+<>_\'\\\w\s]+) # Text
           captures:
@@ -63,27 +63,27 @@
       endCaptures:
         '1':
           name: keyword.control.mermaid
-    - comment: Graph Link With Multiline text
+    - comment: (Graph Link)("Multiline text")(Graph Link)
       begin: !regex |-
         \s*((?:-{2,5}|={2,5})[xo>]?\|) # Start arrow
       beginCaptures:
         '1':
           name: keyword.control.mermaid
       patterns:
-        - comment: ("multi-line text") 
+        - comment: ("multi-line text")
           begin: '\s*(")'
           beginCaptures:
             '1':
               name: string
           patterns:
-            - comment: '(capture inner text between quotes)'
+            - comment: capture inner text between quotes
               begin: !regex |-
                 ([^"]*)
               beginCaptures:
                 '1':
                   name: string
               patterns:
-              # This capture is needed to make the begin capture function
+                # This capture is needed to make the begin capture function
                 - match: '([^"]*)'
                   captures:
                     '1':
@@ -93,7 +93,7 @@
           endCaptures:
             '1':
               name: string
-        - comment: single line text
+        - comment: (single line text)
           match: !regex |-
             \s*([$&%\^/#.,?!;:*+<>_\'\\\w\s]+) # Text
           captures:
@@ -104,8 +104,8 @@
       endCaptures:
         '1':
           name: keyword.control.mermaid
-    - comment: Graph Link With Text
-      match: !regex |-       
+    - comment: (Graph Link Start Arrow)(Text)(Graph Link End Arrow)
+      match: !regex |-
         \s*([xo<]?(?:-{2,5}|={2,5}|-\.{1,3}|-\.)) # Start Arrow        
         ((?:(?!--|==)[\w\s*+%=\\/:\.\-'`,"&^#$!?])*) # Text
         ((?:-{2,5}|={2,5}|\.{1,3}-|\.-)[xo>]?) # End Arrow
@@ -116,13 +116,13 @@
           name: string
         '3':
           name: keyword.control.mermaid
-    - comment: Graph Link
+    - comment: (Graph Link)
       match: !regex |-
         \s*([ox<]?(?:-.{1,3}-|-{1,3}|={1,3})[ox>]?) # Graph Link
       captures:
         '1':
           name: keyword.control.mermaid
-    - comment: Entity  
+    - comment: Entity
       match: (\b(?:(?!--|==)[-\w])+\b\s*)
       name: variable
     - comment: '(Class)(Node(s))(ClassName)'

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -63,6 +63,18 @@
       endCaptures:
         '1':
           name: keyword.control.mermaid
+    - comment: Graph Link With Text
+      match: !regex |-       
+        ([xo<]?(?:-{2,5}|={2,5}|-\.{1,3}|-\.)) # Start Arrow        
+        ((?:(?!--|==)[\w\s*+%=\\/:\.\-'`,"&^#$!?])*) # Text
+        ((?:-{2,5}|={2,5}|\.{1,3}-|\.-)[xo>]?) # End Arrow
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: string
+        '3':
+          name: keyword.control.mermaid
     - comment: Graph Link
       match: !regex |-
         \s*([ox<]?(?:-.{1,3}-|-{1,3}|={1,3})[ox>]?) # Graph Link

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -19,7 +19,7 @@
       name: keyword.control.mermaid
     - comment: '(Entity)(Edge/Shape)(Text)(Edge/Shape)'
       begin: !regex |-
-        (\b[-\w]+\b\s*) # Entity
+        (\b(?:(?!--|==)[-\w])+\b\s*) # Entity
         (\(\[|\[\[|\[\(|\[|\(+|\>|\{|\(\() # Edge/Shape
       beginCaptures:
         '1':
@@ -63,15 +63,15 @@
       endCaptures:
         '1':
           name: keyword.control.mermaid
-    - comment: Entity  
-      match: (\b[-\w]+\b\s*)
-      name: variable
     - comment: Graph Link
       match: !regex |-
         \s*([ox<]?(?:-.{1,3}-|-{1,3}|={1,3})[ox>]?) # Graph Link
       captures:
         '1':
           name: keyword.control.mermaid
+    - comment: Entity  
+      match: (\b(?:(?!--|==)[-\w])+\b\s*)
+      name: variable
     - comment: '(Class)(Node(s))(ClassName)'
       match: !regex |-
         \s*(class) # class

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -63,9 +63,50 @@
       endCaptures:
         '1':
           name: keyword.control.mermaid
+    - comment: Graph Link With Multiline text
+      begin: !regex |-
+        \s*((?:-{2,5}|={2,5})[xo>]?\|) # Start arrow
+      beginCaptures:
+        '1':
+          name: keyword.control.mermaid
+      patterns:
+        - comment: ("multi-line text") 
+          begin: '\s*(")'
+          beginCaptures:
+            '1':
+              name: string
+          patterns:
+            - comment: '(capture inner text between quotes)'
+              begin: !regex |-
+                ([^"]*)
+              beginCaptures:
+                '1':
+                  name: string
+              patterns:
+              # This capture is needed to make the begin capture function
+                - match: '([^"]*)'
+                  captures:
+                    '1':
+                      name: comment
+              end: '(?=")'
+          end: '(")'
+          endCaptures:
+            '1':
+              name: string
+        - comment: single line text
+          match: !regex |-
+            \s*([$&%\^/#.,?!;:*+<>_\'\\\w\s]+) # Text
+          captures:
+            '1':
+              name: string
+      end: !regex |-
+        (\|) # End bracket
+      endCaptures:
+        '1':
+          name: keyword.control.mermaid
     - comment: Graph Link With Text
       match: !regex |-       
-        ([xo<]?(?:-{2,5}|={2,5}|-\.{1,3}|-\.)) # Start Arrow        
+        \s*([xo<]?(?:-{2,5}|={2,5}|-\.{1,3}|-\.)) # Start Arrow        
         ((?:(?!--|==)[\w\s*+%=\\/:\.\-'`,"&^#$!?])*) # Text
         ((?:-{2,5}|={2,5}|\.{1,3}-|\.-)[xo>]?) # End Arrow
       captures:

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -66,6 +66,12 @@
     - comment: Entity  
       match: (\b[-\w]+\b\s*)
       name: variable
+    - comment: Graph Link
+      match: !regex |-
+        \s*([ox<]?(?:-.{1,3}-|-{1,3}|={1,3})[ox>]?) # Graph Link
+      captures:
+        '1':
+          name: keyword.control.mermaid
     - comment: '(Class)(Node(s))(ClassName)'
       match: !regex |-
         \s*(class) # class

--- a/tests/diagrams/graph.test.mermaid
+++ b/tests/diagrams/graph.test.mermaid
@@ -6,6 +6,17 @@ graph TB
   ID-4 
 %%^^^^ variable
   %% Entity[Text]
+  A["
+%%^ variable
+%% ^  keyword.control.mermaid 
+%%  ^ string
+    Hard 
+%%  ^^^^ string
+    edge
+%%  ^^^^ string
+  "]
+%%^ string
+%% ^  keyword.control.mermaid 
   ID-1[Node 1]
 %%^^^^ variable
 %%    ^ keyword.control.mermaid 
@@ -105,6 +116,37 @@ graph TB
 %%                             ^ keyword.control.mermaid
 %%                              ^^^^^^^^^^ string
 %%                                        ^ keyword.control.mermaid
+  A["
+%%^ variable
+%% ^  keyword.control.mermaid 
+%%  ^ string
+    Hard 
+%%  ^^^^ string
+    edge
+%%  ^^^^ string
+  "] -->|"
+%%^ string
+%% ^ keyword.control.mermaid
+%%   ^^^^ keyword.control.mermaid
+%%       ^ string
+    Link
+%%  ^^^^ string
+    text
+%%  ^^^^ string
+  "| B("
+%%^ string
+%% ^ keyword.control.mermaid
+%%   ^ variable
+%%    ^ keyword.control.mermaid
+%%     ^ string
+    Round
+%%  ^^^^ string
+    edge
+%%  ^^^^ string
+  ")
+%%^ string
+%% ^ keyword.control.mermaid
+
   ID-1---ID-2(Text multi word)
 %%^^^^ variable
 %%    ^^^  keyword.control.mermaid 

--- a/tests/diagrams/graph.test.mermaid
+++ b/tests/diagrams/graph.test.mermaid
@@ -46,6 +46,7 @@ graph TB
 %%^^^^ variable
 %%    ^^^ keyword.control.mermaid 
 %%       ^^^^ variable
+  
   ID-1 --> ID-3
 %%^^^^ variable
 %%     ^^^ keyword.control.mermaid 
@@ -193,8 +194,8 @@ graph TB
     ID-5 -. Action from 5 to 4 .-> ID-4
 %%  ^^^^ variable
 %%       ^^  keyword.control.mermaid 
-%%          ^^^^^^^^^^^^^^^^^^^^ string
-%%                              ^^  keyword.control.mermaid 
+%%          ^^^^^^^^^^^^^^^^^^ string
+%%                             ^^  keyword.control.mermaid 
 %%                                 ^^^^ variable
     ID-5==>ID-6
 %%  ^^^^ variable


### PR DESCRIPTION
This is to add multiline support called out in #64.

In order to add multiline support. the graph entities and graph links needed to be re-structured. Previously, the graph links were dependent upon an entity first existing (hanging off of `begin`/`end` patterns identifying an entity). But multiline graph links now required multiple graph link patterns based upon whether the graph link spanned one line or multiple. If the graph link was a multiline text version it needed a different end pattern than a single line version.

With the previous entity structure, each entity pattern would need all of these graph patterns:
* (Entity From)
  * (Graph Link Single Line)
  * (Graph Link Multi Line)
* (Entity From)(Edge Shape)
  * (Graph Link Single Line)
  * (Graph Link Multi Line)

But this could still cause problems for chained links such as:
```
   A -- text --> B -- text2 --> C
```

Instead, entities and graph links needed to be separated so that they can highlight independently and not explode the complexity (and duplication) of the patterns. The new structure defines them separately allowing for the above to work:
* (Entity From)
* (Entity From)(Edge Shape)
* (Graph Link Single Line)
* (Graph Link Multi Line)

The tradeoff is that this now can highlight improper statements such as where the initial entity is missing:
```
   -- text --> B -- text2 --> C
```

But this will reveal itself in whatever renderer the user is using to view the diagrams. And the syntax highlighter shouldn't necessarily be responsible for asserting the syntax is correct.