### PR TITLE
Support curly braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.6.0]
+
+- Add support for curly braces in code block pattern
+
 ## [v1.5.0]
 
 - Add user journey support

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "mermaid-markdown-syntax-highlighting",
 	"displayName": "Mermaid Markdown Syntax Highlighting",
 	"description": "Markdown syntax support for the Mermaid charting language",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"publisher": "bpruitt-goddard",
 	"license": "MIT",
 	"engines": {

--- a/syntaxes/mermaid.tmLanguage-markdown.yaml
+++ b/syntaxes/mermaid.tmLanguage-markdown.yaml
@@ -3,10 +3,16 @@ fileTypes: []
 injectionSelector: L:text.html.markdown
 patterns:
   - include: '#mermaid-code-block'
+  - include: '#mermaid-code-block-with-attributes'
   - include: '#mermaid-ado-code-block'
 repository:
   mermaid-code-block:
     begin: (?<=[`~])mermaid(\s+[^`~]*)?$
+    end: (^|\G)(?=\s*[`~]{3,}\s*$)
+    patterns:
+      - include: '#mermaid'
+  mermaid-code-block-with-attributes:
+    begin: (?<=[`~])\{ *\.mermaid(\s+[^`~]*)?$
     end: (^|\G)(?=\s*[`~]{3,}\s*$)
     patterns:
       - include: '#mermaid'

--- a/tests/markdown/with-attributes.test.mermaid
+++ b/tests/markdown/with-attributes.test.mermaid
@@ -1,0 +1,11 @@
+%% SYNTAX TEST "markdown.mermaid.codeblock" "with attributes markdown test"
+
+```{ .mermaid caption="test" #fig:graph}
+graph LR
+%% <----- keyword.control.mermaid
+%%    ^^ entity.name.function.mermaid
+  A --> B
+%%^ variable
+%%  ^^^ keyword.control.mermaid 
+%%      ^ variable
+```


### PR DESCRIPTION
Adds support for curly braces:
```
    ```{ .mermaid caption="Title" #fig:graph}
    ...
    ```
```

Just a draft. I haven't tested extensively, but I thought I'd share since I needed the functionality myself