### PR TITLE
Replace Broken Readme Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Syntax support for the [Mermaid charting language](https://github.com/knsv/mermaid)
 
-[![Version](https://vsmarketplacebadge.apphb.com/version/bpruitt-goddard.mermaid-markdown-syntax-highlighting.svg)](https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting) [![Installs](https://vsmarketplacebadge.apphb.com/installs/bpruitt-goddard.mermaid-markdown-syntax-highlighting.svg)](https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting) [![Ratings](https://vsmarketplacebadge.apphb.com/rating/bpruitt-goddard.mermaid-markdown-syntax-highlighting.svg)](https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting)
+[![Version](https://img.shields.io/visual-studio-marketplace/v/bpruitt-goddard.mermaid-markdown-syntax-highlighting)](https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting) [![Installs](https://img.shields.io/visual-studio-marketplace/i/bpruitt-goddard.mermaid-markdown-syntax-highlighting)](https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting) [![Ratings](https://img.shields.io/visual-studio-marketplace/r/bpruitt-goddard.mermaid-markdown-syntax-highlighting)](https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting)
 
 Supports both fenced markdown (see screenshots), and mmd files.
 


### PR DESCRIPTION
Fixes the broken badges that were unhelpful but also breaking the deploy of new versions:
![README md — vscode-mermaid-syntax-highlight 2023-02-16 at 4 44 23 PM](https://user-images.githubusercontent.com/2429731/219520738-2d04eeee-24b0-4fd0-8bd5-ab0b6fdadc9c.jpg)
