### PR TITLE
Add excludes and todayMarker keywords for Gantt diagramm

### DIFF
--- a/syntaxes/diagrams/ganttDiagram.yaml
+++ b/syntaxes/diagrams/ganttDiagram.yaml
@@ -31,6 +31,14 @@
         '2':
           name: string
     - match: !regex |-
+        (excludes)\s+ # excludes
+        ((?:[\d\-,]+|monday|tuesday|wednesday|thursday|friday|saturday|sunday|weekends)+) # date or weekday
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: string
+    - match: !regex |-
         (section)\s+ # section
         (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
       captures:

--- a/syntaxes/diagrams/ganttDiagram.yaml
+++ b/syntaxes/diagrams/ganttDiagram.yaml
@@ -32,7 +32,7 @@
           name: string
     - match: !regex |-
         (excludes)\s+ # excludes
-        ((?:[\d\-,]+|monday|tuesday|wednesday|thursday|friday|saturday|sunday|weekends)+) # date or weekday
+        ((?:[\d\-,\s]+|monday|tuesday|wednesday|thursday|friday|saturday|sunday|weekends)+) # date or weekday
       captures:
         '1':
           name: keyword.control.mermaid

--- a/syntaxes/diagrams/ganttDiagram.yaml
+++ b/syntaxes/diagrams/ganttDiagram.yaml
@@ -39,6 +39,14 @@
         '2':
           name: string
     - match: !regex |-
+        ^\s+(todayMarker)\s+ # todayMarker
+        (.*)$ # "off" or styles
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: string
+    - match: !regex |-
         (section)\s+ # section
         (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
       captures:
@@ -47,7 +55,7 @@
         '2':
           name: string
     - begin: !regex |-
-        \s(.*) # Task Text
+        ^\s(.*) # Task Text
         (:) # :
       beginCaptures:
         '1':

--- a/tests/diagrams/gantt.test.mermaid
+++ b/tests/diagrams/gantt.test.mermaid
@@ -2,15 +2,24 @@
 
 gantt
 %% <-------------- keyword.control.mermaid
-  dateFormat  YYYY-MM-DD
+  dateFormat YYYY-MM-DD
 %%^^^^^^^^^^ keyword.control.mermaid
-%%            ^^^^^^^^^^ entity.name.function.mermaid
-  axisFormat  %m/%d/%Y
+%%           ^^^^^^^^^^ entity.name.function.mermaid
+  axisFormat %m/%d/%Y
 %%^^^^^^^^^^ keyword.control.mermaid
-%%            ^^^^^^^^ entity.name.function.mermaid
+%%           ^^^^^^^^ entity.name.function.mermaid
   title Adding GANTT diagram functionality to mermaid
 %%^^^^^ keyword.control.mermaid
 %%      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
+  excludes 2023-02-28
+%%^^^^^^^^ keyword.control.mermaid
+%%         ^^^^^^^^^ string
+  excludes weekends
+%%^^^^^^^^ keyword.control.mermaid
+%%         ^^^^^^^^ string
+  excludes 2023-02-28,sunday,2023-01-01,weekends
+%%^^^^^^^^ keyword.control.mermaid
+%%         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
   section A section %%comment
 %%^^^^^^^ keyword.control.mermaid
 %%        ^^^^^^^^^^^^^^^^^^^ string

--- a/tests/diagrams/gantt.test.mermaid
+++ b/tests/diagrams/gantt.test.mermaid
@@ -19,7 +19,7 @@ gantt
 %%         ^^^^^^^^ string
   excludes 2023-02-28, sunday, 2023-01-01, weekends
 %%^^^^^^^^ keyword.control.mermaid
-%%         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
+%%         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
   todayMarker off
 %%^^^^^^^^^^^ keyword.control.mermaid
 %%            ^^^ string 

--- a/tests/diagrams/gantt.test.mermaid
+++ b/tests/diagrams/gantt.test.mermaid
@@ -13,7 +13,7 @@ gantt
 %%      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
   excludes 2023-02-28
 %%^^^^^^^^ keyword.control.mermaid
-%%         ^^^^^^^^^ string
+%%         ^^^^^^^^^^ string
   excludes weekends
 %%^^^^^^^^ keyword.control.mermaid
 %%         ^^^^^^^^ string

--- a/tests/diagrams/gantt.test.mermaid
+++ b/tests/diagrams/gantt.test.mermaid
@@ -17,7 +17,7 @@ gantt
   excludes weekends
 %%^^^^^^^^ keyword.control.mermaid
 %%         ^^^^^^^^ string
-  excludes 2023-02-28,sunday,2023-01-01,weekends
+  excludes 2023-02-28, sunday, 2023-01-01, weekends
 %%^^^^^^^^ keyword.control.mermaid
 %%         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
   section A section %%comment

--- a/tests/diagrams/gantt.test.mermaid
+++ b/tests/diagrams/gantt.test.mermaid
@@ -20,6 +20,12 @@ gantt
   excludes 2023-02-28, sunday, 2023-01-01, weekends
 %%^^^^^^^^ keyword.control.mermaid
 %%         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
+  todayMarker off
+%%^^^^^^^^^^^ keyword.control.mermaid
+%%            ^^^ string 
+  todayMarker stroke-width:5px,stroke:#0f0,opacity:0.5
+%%^^^^^^^^^^^ keyword.control.mermaid
+%%            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string 
   section A section %%comment
 %%^^^^^^^ keyword.control.mermaid
 %%        ^^^^^^^^^^^^^^^^^^^ string


### PR DESCRIPTION
I've used this syntax plugin recently while developing Gantt diagramm and noticed it doesn't support `excludes` and `todayMarker` keywords. (#99)

![image](https://user-images.githubusercontent.com/5007271/235327878-a8dff920-7fab-449b-a3db-169075fc121e.png)

`excludes` accepts specific dates in YYYY-MM-DD format, days of the week ("sunday") or "weekends", but not the word "weekdays":
- [Playground, excludes with multiple dates and days combined](https://mermaid.live/edit#pako:eNplkk1v2zAMhv8KQaBAC8iBPxLH9i1Y0J7SS3vZoEM1i86E2pJhyVuzIP99stSuGcYTwY-H5CudsTWSsMGj0M5xDd6kcHRvpkE4gK_eksMh2e9jzinXE0TbSan0ER52j8_PIJU4TmKAbtatU0aLXrkTOAMDeZKSsZ3e2n6WZBc_T7N1kmZJWrFPv2bwi-iVtLSx4-YGbl8-2l5AtC2NzoIdqVWdasOyFpS-2hS6sDzzuZMF04H7QYEKtxztrH2Y4x2YCTj-HYYMvs8OtHGx3EzyPb1QOK7uuI4bWQoHwu7Di-EvZhh7ciTBCfsKV9ZIo4kFZclmV8eW7FODCNl54E_6j7BAREixAMn_Vazw6iLDd6X9Y54XGkd_yEAcG-9K6sTcO45cX3ypmJ15OukWGzfNxHAeFx338Q2x6URvfXQUGpszvmGTZHm9Ssu8zrPNdlsV2zxneMImr9JVtU6rslqX9aba1BeGv43xiMyXF8W6SOu8yLK6zBiSVM5Mh_jfwrcLI76F-mWPyx8H1MHe)
- [Example from official docs](https://mermaid.js.org/syntax/gantt.html#syntax)
- [Regex tests](https://regex101.com/r/qXGDe9/1)

`todayMarker` can be either `off` or have a string with styles.
- [Playground, todayMarker with styles](https://mermaid.live/edit#pako:eNpNUctugzAQ_BVrezWRMS_jW9QoPdFLc2nFxcJOYgVsBIsaGuXf60AqdU6j8c7sevcGjdcGJJyUQ6wdCdAKzd4PnUJCPgOiqop2u_UNLbaGrNhqbd2JvG3fDweirToNqiPHyTVovVOtxZmgJ50JSVY_7V6ruVLDxQxkxMFfTPRtNZ5lxvorJU9NvuwZo8T3qgkhkm2y2q3-0SzhZPvHVvnVd31r0GiCaryQf5DaO0OXX5kxpoQznkQsjlhOA00XKmoHFJ5zhlXcHqE14Nl0pgYZqDZHNbVYQ-3uoVRN6D9m14DEYTIUpv6xst26AZBH1Y5B7ZUDeYMryCjm5YblvORxVhQiKTinMIPkgm1EykQu0rzMRFbeKfx4HyLiUJ4kacJSwcqsYElMwWiLfqjWcy1XW3p8LYbHIPdf0YiKvg)
- [Docs](https://mermaid.js.org/syntax/gantt.html#today-marker)

`todayMarker` regex is a little different from others as it also captures `^` and `$` from a string. This is because otherwise `:` will be captured as a part of `Task`, thus breaking highlighting.

Closes #99 