### PR TITLE
fix: add better regex for dateFormat and axisFormat

### DIFF
--- a/syntaxes/diagrams/ganttDiagram.yaml
+++ b/syntaxes/diagrams/ganttDiagram.yaml
@@ -8,7 +8,7 @@
       name: comment
     - match: !regex |-
         (dateFormat)\s+ # dateFormat
-        ([\w-]+) # format
+        ([\w\-\.]+) # format
       captures:
         '1':
           name: keyword.control.mermaid
@@ -16,7 +16,7 @@
           name: entity.name.function.mermaid
     - match: !regex |-
         (axisFormat)\s+ # axisFormat
-        ([\w\%/-]+) # format
+        ([\w\%\/\\\-\.]+) # format
       captures:
         '1':
           name: keyword.control.mermaid

--- a/tests/diagrams/gantt.test.mermaid
+++ b/tests/diagrams/gantt.test.mermaid
@@ -2,7 +2,7 @@
 
 gantt
 %% <-------------- keyword.control.mermaid
-  dateFormat YYYY-MM-DD
+  dateFormat  YYYY-MM-DD
 %%^^^^^^^^^^ keyword.control.mermaid
 %%            ^^^^^^^^^^ entity.name.function.mermaid
   dateFormat  DD.MM.YYYY

--- a/tests/diagrams/gantt.test.mermaid
+++ b/tests/diagrams/gantt.test.mermaid
@@ -4,10 +4,16 @@ gantt
 %% <-------------- keyword.control.mermaid
   dateFormat YYYY-MM-DD
 %%^^^^^^^^^^ keyword.control.mermaid
-%%           ^^^^^^^^^^ entity.name.function.mermaid
-  axisFormat %m/%d/%Y
+%%            ^^^^^^^^^^ entity.name.function.mermaid
+  dateFormat  DD.MM.YYYY
 %%^^^^^^^^^^ keyword.control.mermaid
-%%           ^^^^^^^^ entity.name.function.mermaid
+%%            ^^^^^^^^^^ entity.name.function.mermaid
+  axisFormat  %m/%d/%Y
+%%^^^^^^^^^^ keyword.control.mermaid
+%%            ^^^^^^^^ entity.name.function.mermaid
+  axisFormat  %d..text//%m\\test--%y
+%%^^^^^^^^^^ keyword.control.mermaid
+%%            ^^^^^^^^^^^^^^^^^^^^^^ entity.name.function.mermaid
   title Adding GANTT diagram functionality to mermaid
 %%^^^^^ keyword.control.mermaid
 %%      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string


### PR DESCRIPTION
Fixes #100 

![image](https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight/assets/5007271/3b99d20a-1b91-47ba-9e25-2a622a391dc4)

[Regex playground](https://regex101.com/r/anOH3S/1)
[Mermaid playground](https://mermaid.live/edit#pako:eNplUcFuwjAM_ZXIErcSmrSUkhsa2o3TdtmUS0QMVGsT1LoTDPHvc9uhTdo7vTz7vVj2DfbRIxg4ukBkg2BQRTWKV-x-3t4RPse2cSTEdit3O_nGmGruUnWP2mLmpSS80GIxayyDOGI-n11tmJo73FMVg9g82CQ_xeZcI6EX5LoP8QfGx4DJwNJCpkrqVOWJSMsHn_wbzvrEf-bB78YSJ3jsNDvXvymZtwESaJCHrzxv4DakWaATNmjBMPV4cH1NFmy4c6vrKb5cwx4MtT0m0J-HzWwrd2xdA-bg6o7VswtgbnABMy9zWahVmWmda1UUSidwBaOzUuZluWZhqdNiVWT3BL5i5AglM7VWLJdKpcs0V8sE0FcU2910pfFY4x_vo2EY5P4Nd9OBmA) (also a proof that it's a valid usecase)