### PR TITLE
Sequence Actors Match Ending Parentheses

### DIFF
--- a/syntaxes/diagrams/sequenceDiagram.yaml
+++ b/syntaxes/diagrams/sequenceDiagram.yaml
@@ -35,7 +35,7 @@
     - comment: '(activate/deactivate)(Actor)'
       match: !regex |-
         \s*((?:de)?activate) # Activate/Deactivate
-        \s+(\b["\(\)$&%\^/#.?!*=<>\'\\\w\s]+\b\s*) # Actor
+        \s+(\b["()$&%^/#.?!*=<>'\\\w\s]+\b\)?\s*) # Actor
       captures:
         '1':
           name: keyword.control.mermaid
@@ -45,9 +45,9 @@
       match: !regex |-
         \s*(Note) # Note
         \s+((?:left|right)\sof|over) # Direction
-        \s+(\b["\(\)$&%\^/#.?!*=<>\'\\\w\s]+\b\s*) # Actor
+        \s+(\b["()$&%^/#.?!*=<>'\\\w\s]+\b\)?\s*) # Actor
         (,)? # ,?
-        (\b["\(\)$&%\^/#.?!*=<>\'\\\w\s]+\b\s*)? # Actor
+        (\b["()$&%^/#.?!*=<>'\\\w\s]+\b\)?\s*)? # Actor
         (:) # :
         (?:\s+([^;#]*))? # Message
       captures:
@@ -91,11 +91,11 @@
     - comment: '(Actor)(Arrow)(Actor)(:)(Message)'
       match: !regex |-
         \s*
-        (\b["\(\)$&%\^/#.?!*=<>\'\\\w\s]+\b) # Actor
+        (\b["()$&%^/#.?!*=<>'\\\w\s]+\b\)?) # Actor
         \s*
         (-?-(?:\>|x|\))\>?[+-]?) # Arrow
         \s*
-        (["\(\)$&%\^/#.?!*=<>\'\\\w\s]+\b) # Actor
+        (["()$&%^/#.?!*=<>'\\\w\s]+\b\)?) # Actor
         \s*
         (:) # :
         \s*

--- a/tests/diagrams/sequence.test.mermaid
+++ b/tests/diagrams/sequence.test.mermaid
@@ -94,6 +94,12 @@ sequenceDiagram
 %%     ^ variable
 %%      ^ keyword.control.mermaid 
 %%        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
+  Participant1 (with brackets) -->Backend (with brackets) : wrong on this line
+%%^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variable
+%%                             ^^^ keyword.control.mermaid
+%%                                ^^^^^^^^^^^^^^^^^^^^^^^ variable
+%%                                                        ^ keyword.control.mermaid 
+%%                                                          ^^^^^^^^^^^^^^^^^^ string
   deactivate Alice
 %%^^^^^^^^^^ keyword.control.mermaid
 %%           ^^^^^ variable
@@ -104,6 +110,12 @@ sequenceDiagram
 %%             ^^^^^ variable
 %%                  ^ keyword.control.mermaid 
 %%                    ^^^^^^^^^^^^^^^^^^^ string
+  Note left of Alice (brackets): Alice likes to chat
+%%^^^^ keyword.control.mermaid
+%%     ^^^^^^^ entity.name.function.mermaid
+%%             ^^^^^^^^^^^^^^^^ variable
+%%                             ^ keyword.control.mermaid 
+%%                               ^^^^^^^^^^^^^^^^^^^ string
   Note over B,C: Bob whispers when sick
 %%^^^^ keyword.control.mermaid
 %%     ^^^^ entity.name.function.mermaid


### PR DESCRIPTION
Fixes #90. The problem wasn't with the `end` keyword, but the way the Actor was being matched. In this case, it didn't properly handle ending parentheses, which caused the whole line to not be treated as a proper "(Actor)(Arrow)(Actor)(:)(Message)" line and thus fallback to only looking for `end` within the line.

With the change, this line is properly highlighted:
<img width="722" alt="image" src="https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight/assets/2429731/e74b2406-73b1-4b6d-b12b-ff5e63c1248b">

