### PR TITLE
Add Sequence Critical Keyword Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v1.5.3]
+
+- Fix sequence actors matching ending parentheses
+- Add sequence critical
+
 ## [v1.5.2]
 
 - Add gantt excludes and todaymarker

--- a/build/ConvertYaml.js
+++ b/build/ConvertYaml.js
@@ -18,7 +18,7 @@ fs.readdirSync(path.join(__dirname, FILE_DIR))
     var inputName = path.join(INPUT_DIR, file);
     var outputName = path.join(
       OUTPUT_DIR,
-      path.parse(inputName).name + '.json'
+      path.parse(inputName).name + '.json',
     );
     var res = read(inputName, null, GRAMMAR_SCHEMA);
 

--- a/build/CustomYamlTypes.js
+++ b/build/CustomYamlTypes.js
@@ -35,7 +35,7 @@ if (require.main === module) {
       } else {
         console.error(error.stack || error.message || String(error));
       }
-    }
+    },
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Mermaid Markdown Syntax Highlighting",
 	"description": "Markdown syntax support for the Mermaid charting language",
 	"icon": "images/icon/iconPNG.png",
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"publisher": "bpruitt-goddard",
 	"license": "MIT",
 	"engines": {

--- a/syntaxes/diagrams/sequenceDiagram.yaml
+++ b/syntaxes/diagrams/sequenceDiagram.yaml
@@ -79,9 +79,9 @@
       captures:
         '1':
           name: keyword.control.mermaid
-    - comment: '(alt/else/opt/par/and/autonumber)(text)'
+    - comment: '(alt/else/option/par/and/autonumber/critical/opt)(text)'
       match: !regex |-
-        \s*(alt|else|opt|par|and|rect|autonumber) # alt/else/opt/par/and/rect/autonumber
+        \s*(alt|else|option|par|and|rect|autonumber|critical|opt) # keyword
         (?:\s+([^#;]*))? # text
       captures:
         '1':

--- a/tests/diagrams/sequence.test.mermaid
+++ b/tests/diagrams/sequence.test.mermaid
@@ -198,5 +198,25 @@ sequenceDiagram
 %%      ^ variable
 %%       ^ keyword.control.mermaid
 %%         ^^^^^^^^^^^^^ string
+  critical Establish a connection to the DB
+%%^^^^^^^^ keyword.control.mermaid
+%%         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
+    Service-->DB: connect
+%%  ^^^^^^^ variable
+%%         ^^^ keyword.control.mermaid
+%%            ^^ variable
+%%              ^ keyword.control.mermaid
+%%                ^^^^^^^ string
+  option Network timeout
+%%^^^^^^ keyword.control.mermaid
+%%       ^^^^^^^^^^^^^^^ string
+    Service-->Service: Log error
+%%  ^^^^^^^ variable
+%%         ^^^ keyword.control.mermaid
+%%            ^^^^^^^ variable
+%%                   ^ keyword.control.mermaid
+%%                     ^^^^^^^^^ string
+  end
+%%^^^ keyword.control.mermaid
 end
 %% <--- keyword.control.mermaid


### PR DESCRIPTION
Adds support for `critical` keyword in sequence diagrams:
<img width="396" alt="image" src="https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight/assets/2429731/cb7c5d87-68e4-494a-aeea-a82075174b37">


Also bumps version to push out latest changes.
Fixes #107 