### PR TITLE
syntax: add box keyword for sequenceDiagram

### DIFF
--- a/syntaxes/diagrams/sequenceDiagram.yaml
+++ b/syntaxes/diagrams/sequenceDiagram.yaml
@@ -111,4 +111,25 @@
           name: keyword.control.mermaid
         '5':
           name: string
+    - comment: '(box transparent text)'
+      match: !regex |-
+        \s*(box) # box
+        \s+(transparent) # transparent box background
+        (?:\s+([^;#]*))? # Box Text
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: entity.name.function.mermaid
+        '3':
+          name: string
+    - comment: '(box text)'
+      match: !regex |-
+        \s*(box) # box
+        (?:\s+([^;#]*))? # Box Text
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: string
   end: (^|\G)(?=\s*[`:~]{3,}\s*$)

--- a/tests/diagrams/sequence.test.mermaid
+++ b/tests/diagrams/sequence.test.mermaid
@@ -220,3 +220,10 @@ sequenceDiagram
 %%^^^ keyword.control.mermaid
 end
 %% <--- keyword.control.mermaid
+  box transparent A colorless box with text
+%%^^^ keyword.control.mermaid
+%%    ^^^^^^^^^^^ entity.name.function.mermaid
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^ string
+  box Aqua My Boxy Box
+%%^^^ keyword.control.mermaid
+%%    ^^^^^^^^^^^^^^^^ string


### PR DESCRIPTION
This adds a new rule + test coverage for capturing the `box` keyword as described in the docs here:

https://mermaid.js.org/syntax/sequenceDiagram.html#grouping-box

Resolves this scenario:

<img width="207" alt="image" src="https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight/assets/16504501/3af986cf-011d-49df-9285-ee8643f285d4">
