### PR TITLE
feat: Add syntax for tickInterval in gannt diagram

### DIFF
--- a/syntaxes/diagrams/ganttDiagram.yaml
+++ b/syntaxes/diagrams/ganttDiagram.yaml
@@ -23,6 +23,14 @@
         '2':
           name: entity.name.function.mermaid
     - match: !regex |-
+        (tickInterval)\s+ # tickInterval
+        (([1-9][0-9]*)(millisecond|second|minute|hour|day|week|month)) # format
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: string
+    - match: !regex |-
         (title)\s+ # title
         (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
       captures:

--- a/tests/diagrams/gantt.test.mermaid
+++ b/tests/diagrams/gantt.test.mermaid
@@ -28,10 +28,16 @@ gantt
 %%         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
   todayMarker off
 %%^^^^^^^^^^^ keyword.control.mermaid
-%%            ^^^ string 
+%%            ^^^ string
   todayMarker stroke-width:5px,stroke:#0f0,opacity:0.5
 %%^^^^^^^^^^^ keyword.control.mermaid
-%%            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string 
+%%            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
+  tickInterval 1day
+%%^^^^^^^^^^^^ keyword.control.mermaid
+%%             ^^^^ string
+  tickInterval 600millisecond
+%%^^^^^^^^^^^^ keyword.control.mermaid
+%%             ^^^^^^^^^^^^^^ string
   section A section %%comment
 %%^^^^^^^ keyword.control.mermaid
 %%        ^^^^^^^^^^^^^^^^^^^ string


### PR DESCRIPTION
tickInterval was an option in gannt, added it to the ganntDiagram.yaml syntax.