### PR TITLE
Highlight Case Insensitive Keywords

### DIFF
--- a/build/CustomYamlTypes.js
+++ b/build/CustomYamlTypes.js
@@ -9,7 +9,8 @@ var RegexYamlType = new yaml.Type('!regex', {
   kind: 'scalar',
   construct: function (data) {
     return (
-      data
+      // Make regex case-insensitive since this cannot be applied globally
+      `(?i)${data}`
         //Remove end of line comments (space then #)
         .replace(/(^|\s)#.*/g, '')
         //Remove new lines from yaml multistring

--- a/syntaxes/diagrams/ganttDiagram.yaml
+++ b/syntaxes/diagrams/ganttDiagram.yaml
@@ -7,7 +7,7 @@
     - match: \%%.*
       name: comment
     - match: !regex |-
-        (dateFormat)\s+ # dateFormat
+        ^\s*(dateFormat)\s+ # dateFormat
         ([\w\-\.]+) # format
       captures:
         '1':
@@ -15,7 +15,7 @@
         '2':
           name: entity.name.function.mermaid
     - match: !regex |-
-        (axisFormat)\s+ # axisFormat
+        ^\s*(axisFormat)\s+ # axisFormat
         ([\w\%\/\\\-\.]+) # format
       captures:
         '1':
@@ -31,7 +31,7 @@
         '2':
           name: string
     - match: !regex |-
-        (title)\s+ # title
+        ^\s*(title)\s+ # title
         (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
       captures:
         '1':
@@ -39,7 +39,7 @@
         '2':
           name: string
     - match: !regex |-
-        (excludes)\s+ # excludes
+        ^\s*(excludes)\s+ # excludes
         ((?:[\d\-,\s]+|monday|tuesday|wednesday|thursday|friday|saturday|sunday|weekends)+) # date or weekday
       captures:
         '1':
@@ -55,7 +55,7 @@
         '2':
           name: string
     - match: !regex |-
-        (section)\s+ # section
+        ^\s*(section)\s+ # section
         (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
       captures:
         '1':

--- a/syntaxes/diagrams/gitGraph.yaml
+++ b/syntaxes/diagrams/gitGraph.yaml
@@ -8,7 +8,7 @@
       name: comment
     - comment: commit
       begin: !regex |-
-        \s*(commit) # commit
+        ^\s*(commit) # commit
       beginCaptures:
         '1':
           name: keyword.control.mermaid
@@ -52,7 +52,7 @@
       end: '$'
     - comment: '(checkout) (branch-name)'
       match: !regex |-
-        \s*(checkout) # checkout
+        ^\s*(checkout) # checkout
         \s*([^\s"]*) # branch-name
       captures:
         '1':
@@ -61,7 +61,7 @@
           name: variable
     - comment: '(branch) (branch-name) (order)?(:) (number)'
       match: !regex |-
-        \s*(branch) # branch
+        ^\s*(branch) # branch
         \s*([^\s"]*) # branch-name
         \s*(?:(order)(:)\s?(\d+))? # (order)(:) (number)
       captures:
@@ -77,7 +77,7 @@
           name: constant.numeric.decimal.mermaid
     - comment: '(merge) (branch-name) (tag: "tag-name")?'
       match: !regex |-
-        \s*(merge) # merge
+        ^\s*(merge) # merge
         \s*([^\s"]*) # branch-name
         \s*(?:(tag)(:)\s?("[^"\n]*"))? # (tag: "tag-name")?
       captures:
@@ -93,7 +93,7 @@
           name: string
     - comment: '(cherry-pick) (id)(:)("commit-id")'
       match: !regex |-
-        \s*(cherry-pick) # cherry-pick
+        ^\s*(cherry-pick) # cherry-pick
         \s+(id) # id
         (:) # :
         \s*("[^"\n]*") # "commit-id"

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -10,7 +10,7 @@
       name: comment
     - comment: ''
       match: !regex |-
-        \b(subgraph)\s+
+        ^\s*(subgraph)\s+
         (\w+)
         (\[)
         ("?[\w\s*+%=\\/:\.\-'`,&^#$!?<>]*"?)
@@ -26,7 +26,7 @@
           name: string
         '5':
           name: keyword.control.mermaid
-    - match: \b(subgraph)\s+([\p{Letter}\ 0-9<>]+)
+    - match: ^\s*(subgraph)\s+([\p{Letter}\ 0-9<>]+)
       captures:
         '1':
           name: keyword.control.mermaid

--- a/syntaxes/diagrams/pieChart.yaml
+++ b/syntaxes/diagrams/pieChart.yaml
@@ -7,7 +7,7 @@
     - match: \%%.*
       name: comment
     - match: !regex |-
-        (title)\s+ # title
+        ^\s*(title)\s+ # title
         (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
       captures:
         '1':

--- a/syntaxes/diagrams/quadrantChart.yaml
+++ b/syntaxes/diagrams/quadrantChart.yaml
@@ -7,7 +7,7 @@
     - match: \%%.*
       name: comment
     - match: !regex |-
-        (title) # title
+        ^\s*(title) # title
         \s*(["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
       captures:
         '1':
@@ -16,7 +16,7 @@
           name: string
     - comment: '(x|y-axis) (text) (-->)? (text)?'
       begin: !regex |-
-        ([xy]-axis) # x|y-axis
+        ^\s*([xy]-axis) # x|y-axis
         \s+((?:(?!-->)[$&%/#.,?!*+=\'\\\-\w\s])*) # text
       beginCaptures:
         '1':
@@ -35,7 +35,7 @@
               name: string
       end: '$'
     - match: !regex |-
-        (quadrant-[1234]) # quadrant-x
+        ^\s*(quadrant-[1234]) # quadrant-x
         \s*(["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
       captures:
         '1':

--- a/syntaxes/diagrams/requirementDiagram.yaml
+++ b/syntaxes/diagrams/requirementDiagram.yaml
@@ -8,7 +8,7 @@
       name: comment
     - comment: (requirement) (name) ({)
       begin: !regex |-
-        ^\s*((?i)(?:functional|interface|performance|physical)?requirement|designConstraint) # requirement
+        ^\s*((?:functional|interface|performance|physical)?requirement|designConstraint) # requirement
         \s*(["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # name
         \s*({) # }
       beginCaptures:
@@ -84,7 +84,7 @@
               name: variable
         - comment: (docref:) (user ref)
           match: !regex |-
-            \s*(?i)(docref:) # docref:
+            \s*(docref:) # docref:
             \s*([$&%\^/#.,?!;:*+<>_\'\\\w\s]+) # user ref
           captures:
             '1':
@@ -100,7 +100,7 @@
       match: !regex |-
         ^\s*([\w]+) # source
         \s*(-) # -
-        \s*((?i)contains|copies|derives|satisfies|verifies|refines|traces) # type
+        \s*(contains|copies|derives|satisfies|verifies|refines|traces) # type
         \s*(->) # ->
         \s*([\w]+)\s*$ # destination
       captures:
@@ -118,7 +118,7 @@
       match: !regex |-
         ^\s*([\w]+) # destination
         \s*(<-) # <-
-        \s*((?i)contains|copies|derives|satisfies|verifies|refines|traces) # type
+        \s*(contains|copies|derives|satisfies|verifies|refines|traces) # type
         \s*(-) # -
         \s*([\w]+)\s*$ # source
       captures:

--- a/syntaxes/diagrams/sequenceDiagram.yaml
+++ b/syntaxes/diagrams/sequenceDiagram.yaml
@@ -82,7 +82,7 @@
     - comment: '(alt/else/option/par/and/autonumber/critical/opt)(text)'
       match: !regex |-
         \s*(alt|else|option|par|and|rect|autonumber|critical|opt) # keyword
-        (?:\s+([^#;]*))? # text
+        (?:\s+([^#;]*))?$ # text? <end of line>
       captures:
         '1':
           name: keyword.control.mermaid

--- a/syntaxes/diagrams/stateDiagram.yaml
+++ b/syntaxes/diagrams/stateDiagram.yaml
@@ -124,7 +124,7 @@
           name: string
     - comment: 'note left|right of (state name)'
       match: !regex |-
-        (note (?:left|right) of) # note left|right of
+        ^\s*(note (?:left|right) of) # note left|right of
         \s+([\w-]+) # state name
         \s+(:) # :
         \s*([^\n:]+) # note text
@@ -139,7 +139,7 @@
           name: string
     - comment: 'note left|right of (state name) (note text) end note'
       begin: !regex |-
-        (note (?:left|right) of) # note left|right of
+        ^\s*(note (?:left|right) of) # note left|right of
         \s+([\w-]+)(.|\n) # state name
       beginCaptures:
         '1':

--- a/syntaxes/diagrams/stateDiagram.yaml
+++ b/syntaxes/diagrams/stateDiagram.yaml
@@ -33,14 +33,14 @@
           name: string
     - comment: 'state'
       begin: !regex |-
-        (state) # state
+        ^\s*(state)\s+ # state
       beginCaptures:
         '1':
           name: keyword.control.mermaid
       patterns:
         - comment: '"(description)" as (state)'
           match: !regex |-
-            \s+("[-\w\s]+\b") # description
+            \s*("[-\w\s]+\b") # description
             \s+(as) # as
             \s+([\w-]+) # state name
           captures:
@@ -52,7 +52,7 @@
               name: variable
         - comment: '(state name) {'
           match: !regex |-
-            \s+([\w-]+) # state name
+            \s*([\w-]+) # state name
             \s+({) # {
           captures:
             '1':
@@ -61,7 +61,7 @@
               name: keyword.control.mermaid
         - comment: '(state name) <<fork|join>>'
           match: !regex |-
-            \s+([\w-]+) # state name
+            \s*([\w-]+) # state name
             \s+(<<(?:fork|join)>>) # <<fork|join>>
           captures:
             '1':

--- a/syntaxes/diagrams/userJourney.yaml
+++ b/syntaxes/diagrams/userJourney.yaml
@@ -7,7 +7,7 @@
     - match: \%%.*
       name: comment
     - match: !regex |-
-        (title|section)\s+ # title or section
+        ^\s*(title|section)\s+ # title or section
         (\s*["\(\)$&%\^/#.,?!;:*+=<>\'\\\-\w\s]*) # text
       captures:
         '1':

--- a/tests/diagrams/gantt.test.mermaid
+++ b/tests/diagrams/gantt.test.mermaid
@@ -106,3 +106,15 @@ gantt
 %%^^^^^^^^^^^^^^ string
 %%                                    ^ keyword.control.mermaid
 %%                                     ^^ source.mermaid
+
+  %% negative cases
+  invalid_title
+%%^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+  invalid_excludes monday
+%%^^^^^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+  invalid_section
+%%^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+  invalid_axisFormat 44
+%%^^^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+  invalid_dateFormat  DD.MM.YYYY
+%%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid

--- a/tests/diagrams/gitGraph.test.mermaid
+++ b/tests/diagrams/gitGraph.test.mermaid
@@ -92,3 +92,15 @@ gitGraph
 %%            ^^ keyword.control.mermaid
 %%              ^ keyword.control.mermaid
 %%               ^^^^^^^^ string
+
+  %% negative cases
+  invalid_commit
+%%^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+  invalid_checkout
+%%^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+  invalid_branch
+%%^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+  invalid_merge
+%%^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+  invalid_cherry-pick id:"anId"
+%%^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid

--- a/tests/diagrams/graph.test.mermaid
+++ b/tests/diagrams/graph.test.mermaid
@@ -275,3 +275,7 @@ graph TB
 %%~~~ keyword.control.mermaid
 end
 %% <--- keyword.control.mermaid
+
+  %% negative cases
+  invalid subgraph invalid
+%%^^^^^^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid

--- a/tests/diagrams/pie.test.mermaid
+++ b/tests/diagrams/pie.test.mermaid
@@ -21,3 +21,7 @@ pie
 %%  ^^^^^^ string
 %%         ^ keyword.control.mermaid
 %%            ^ source.mermaid
+
+  %% negative cases
+  invalid title invalid
+%%^^^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid

--- a/tests/diagrams/quadrantChart.test.mermaid
+++ b/tests/diagrams/quadrantChart.test.mermaid
@@ -51,3 +51,11 @@ quadrantChart
 %%                   ^ keyword.control.mermaid
 %%                     ^^^^ constant.numeric.decimal.mermaid
 %%                         ^ keyword.control.mermaid
+
+    %% negative cases
+    invalid title invalid
+%%  ^^^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+    invalid x-axis text
+%%  ^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+    invalid quadrant-1 text
+%%  ^^^^^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid

--- a/tests/diagrams/state.test.mermaid
+++ b/tests/diagrams/state.test.mermaid
@@ -129,3 +129,7 @@ stateDiagram
 %%                                 ^^^^^^^^^^^^^^^^^ string
   }
 %%^ keyword.control.mermaid
+
+  %% negative cases
+  invalid note left of blah
+%%^^^^^^^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid

--- a/tests/diagrams/userJourney.test.mermaid
+++ b/tests/diagrams/userJourney.test.mermaid
@@ -22,3 +22,9 @@ journey
 %%              ^^ variable
 %%                ^ source.mermaid
 %%                  ^^^^^^^^^^^^^^^^^^ variable
+
+  %% negative cases
+  invalid title text
+%%^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+  invalid section text
+%%^^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid


### PR DESCRIPTION
Fixes #131 , but also extends this support to all keywords across all diagrams. I hadn't previously realized, but in order to make keyword matching case-insensitive, the associated regex flag `(?i)` needs to be applied to _each_ line in the tmgrammar file.  Fortunately, with the existing custom yaml converter this can be done automatically when building the json language file. 
Once this was added, it was observed that it is possible for some keywords to match in the middle of a line when they should only match at the start of the line. The regexes were updated to only match at the beginning of a line (aside from whitespace), and negative tests were generated to ensure that they do not highlight in this case.