### PR TITLE
Fix Graph Subgraph Direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v1.6.4]
+
+- Make all keywords case-insensitive
+- Fix graph subgraph direction
+
 ## [v1.6.3]
 
 - Add quadrant chart support

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Mermaid Markdown Syntax Highlighting",
 	"description": "Markdown syntax support for the Mermaid charting language",
 	"icon": "images/icon/iconPNG.png",
-	"version": "1.6.3",
+	"version": "1.6.4",
 	"publisher": "bpruitt-goddard",
 	"license": "MIT",
 	"engines": {

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -32,8 +32,13 @@
           name: keyword.control.mermaid
         '2':
           name: entity.name.function.mermaid
-      name: meta.function.mermaid
-    - match: \b(end|RB|BT|RL|TD|LR)\b
+    - match: ^(?i)\s*(direction)\s+(RB|BT|RL|TD|LR)
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: entity.name.function.mermaid
+    - match: \b(end)\b
       name: keyword.control.mermaid
     - comment: '(Entity)(Edge/Shape)(Text)(Edge/Shape)'
       begin: !regex |-

--- a/tests/diagrams/graph.test.mermaid
+++ b/tests/diagrams/graph.test.mermaid
@@ -271,6 +271,24 @@ graph TB
 %%          ^ keyword.control.mermaid
 %%           ^^^^^ string
 %%                ^ keyword.control.mermaid
+    direction RL
+%%  ^^^^^^^^^ keyword.control.mermaid
+%%            ^^ entity.name.function.mermaid
+    direction BT
+%%  ^^^^^^^^^ keyword.control.mermaid
+%%            ^^ entity.name.function.mermaid
+    direction RB
+%%  ^^^^^^^^^ keyword.control.mermaid
+%%            ^^ entity.name.function.mermaid
+    direction RL
+%%  ^^^^^^^^^ keyword.control.mermaid
+%%            ^^ entity.name.function.mermaid
+    direction TD
+%%  ^^^^^^^^^ keyword.control.mermaid
+%%            ^^ entity.name.function.mermaid
+    direction LR
+%%  ^^^^^^^^^ keyword.control.mermaid
+%%            ^^ entity.name.function.mermaid
   end
 %%~~~ keyword.control.mermaid
 end


### PR DESCRIPTION
The subgraph direction was not properly highlighting:
![image](https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight/assets/2429731/158f7cf8-b5bb-43b2-9272-104f85277f38)

This PR fixes the highlighting:
![image](https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight/assets/2429731/b1b5eec6-f260-4497-8deb-f9c40bfb35b9)

It also bumps the versioning to include both this change and the last PR #134 .