### PR TITLE
Fix Github Action Deployment

### DIFF
--- a/.github/workflows/master-merge.yml
+++ b/.github/workflows/master-merge.yml
@@ -4,15 +4,13 @@
 name: 'Github Master Merge'
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
+    branches: master
     paths:
       - 'CHANGELOG.md'
 
 jobs:
   deploy:
-    if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The github action for performing a deployment was triggering on a pull request merge. But this was being done within the context of the source branch, which does not have access to the repository's secrets. Namely the access token for deploying a new version of the extension.
Instead of basing this action on the PR merge, this new approach bases on a push to the master branch, which should always operate within the context of someone with access to the secrets. See [this github discussion](https://github.com/orgs/community/discussions/25588).
This shouldn't change _when_ the deployments happen, it should simply allow the action to have access to the necessary secret.