### PR TITLE
Update dependencies and use ESM

### DIFF
--- a/.github/workflows/github-pr.yml
+++ b/.github/workflows/github-pr.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.4.x]
+        node-version: [22]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v34
 
       - name: Prettier check
         uses: creyD/prettier_action@v4.3
@@ -30,7 +30,7 @@ jobs:
           prettier_options: --check **/*.{js,yaml,md}
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/github-pr.yml
+++ b/.github/workflows/github-pr.yml
@@ -21,7 +21,7 @@ jobs:
         node-version: [22]
     steps:
       - name: Checkout
-        uses: actions/checkout@v34
+        uses: actions/checkout@v4
 
       - name: Prettier check
         uses: creyD/prettier_action@v4.3

--- a/.github/workflows/master-merge.yml
+++ b/.github/workflows/master-merge.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.4.x]
+        node-version: [22]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ To test changes locally:
 
 ```sh
 npm install
-vsce package
+npx @vscode/vsce package
 ```
 
 2. Install the theme locally by using the `Install from VSIX` command. This may require reloading VS Code to see the changes.

--- a/build/ConvertYaml.mjs
+++ b/build/ConvertYaml.mjs
@@ -1,9 +1,11 @@
-'use strict';
+import fs from 'fs-extra';
+import { GRAMMAR_SCHEMA } from './CustomYamlTypes.mjs';
+import { read } from 'yaml-import';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-var fs = require('fs-extra');
-var GRAMMAR_SCHEMA = require('./CustomYamlTypes').GRAMMAR_SCHEMA;
-var read = require('yaml-import').read;
-var path = require('path');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const FILE_DIR = '../syntaxes/',
   DIR_OUT = '../out',
@@ -15,12 +17,12 @@ fs.ensureDirSync(path.join(__dirname, DIR_OUT));
 fs.readdirSync(path.join(__dirname, FILE_DIR))
   .filter((file) => path.extname(file) === '.yaml')
   .forEach((file) => {
-    var inputName = path.join(INPUT_DIR, file);
-    var outputName = path.join(
+    const inputName = path.join(INPUT_DIR, file);
+    const outputName = path.join(
       OUTPUT_DIR,
       path.parse(inputName).name + '.json',
     );
-    var res = read(inputName, null, GRAMMAR_SCHEMA);
+    const res = read(inputName, { schema: GRAMMAR_SCHEMA });
 
     fs.writeFileSync(outputName, JSON.stringify(res, null, 2), {
       encoding: 'utf8',

--- a/build/CustomYamlTypes.mjs
+++ b/build/CustomYamlTypes.mjs
@@ -1,11 +1,10 @@
-'use strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import util from 'node:util';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
 
-var fs = require('fs');
-var path = require('path');
-var util = require('util');
-var yaml = require('js-yaml');
-
-var RegexYamlType = new yaml.Type('!regex', {
+export const RegexYamlType = new yaml.Type('!regex', {
   kind: 'scalar',
   construct: function (data) {
     return (
@@ -19,16 +18,17 @@ var RegexYamlType = new yaml.Type('!regex', {
   },
 });
 
-var GRAMMAR_SCHEMA = yaml.Schema.create(yaml.SAFE_SCHEMA, [RegexYamlType]);
+export const GRAMMAR_SCHEMA = yaml.DEFAULT_SCHEMA.extend([RegexYamlType]);
 
 // do not execute the following if file is required (http://stackoverflow.com/a/6398335)
-if (require.main === module) {
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv?.[1] === __filename) {
   // And read a document using that schema.
   fs.readFile(
     path.join(__dirname, 'custom_types.yml'),
     'utf8',
     function (error, data) {
-      var loaded;
+      let loaded;
 
       if (!error) {
         loaded = yaml.load(data, { schema: GRAMMAR_SCHEMA });
@@ -39,7 +39,3 @@ if (require.main === module) {
     },
   );
 }
-
-// There are some exports to play with this example interactively.
-module.exports.RegexYamlType = RegexYamlType;
-module.exports.GRAMMAR_SCHEMA = GRAMMAR_SCHEMA;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
 	"name": "mermaid-markdown-syntax-highlighting",
-	"version": "1.6.7",
+	"version": "1.7.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mermaid-markdown-syntax-highlighting",
-			"version": "1.6.7",
+			"version": "1.7.0",
 			"license": "MIT",
 			"devDependencies": {
 				"fs-extra": "^11.2.0",
 				"js-yaml": "^4.1.0",
+				"prettier": "^3.3.3",
 				"vscode-tmgrammar-test": "^0.1.3",
 				"yaml-import": "^3.0.0"
 			},
@@ -577,6 +578,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+			"integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/require-from-string": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,39 +1,35 @@
 {
-	"name": "forked-mermaid-markdown-syntax-highlighting",
-	"version": "1.0.0",
-	"lockfileVersion": 2,
+	"name": "mermaid-markdown-syntax-highlighting",
+	"version": "1.6.7",
+	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "forked-mermaid-markdown-syntax-highlighting",
-			"version": "1.0.0",
+			"name": "mermaid-markdown-syntax-highlighting",
+			"version": "1.6.7",
 			"license": "MIT",
 			"devDependencies": {
-				"js-yaml": "^3.13.1",
-				"prettier": "^3.3.3",
-				"vscode-tmgrammar-test": "^0.1.1",
-				"yaml-import": "^2.0.0"
+				"fs-extra": "^11.2.0",
+				"js-yaml": "^4.1.0",
+				"vscode-tmgrammar-test": "^0.1.3",
+				"yaml-import": "^3.0.0"
 			},
 			"engines": {
+				"node": ">=22.0.0",
 				"vscode": "^1.19.0"
 			}
 		},
-		"node_modules/@types/normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
-			"dev": true
-		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -45,6 +41,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -53,43 +50,55 @@
 			}
 		},
 		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+			"integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
+			"license": "Python-2.0"
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/bottleneck": {
+			"version": "2.19.5",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+			"integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=6"
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/chalk": {
@@ -97,6 +106,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -107,34 +117,50 @@
 			}
 		},
 		"node_modules/cli-belt": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cli-belt/-/cli-belt-0.3.1.tgz",
-			"integrity": "sha512-cQfBIWcwZCXAGLLdyH5XAMmP3KWnqOTWH4HO8a2J/ALEHA59TzLQ+KeOxc2b1I1NSfekvchWexq4EnRctELo0g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/cli-belt/-/cli-belt-2.0.2.tgz",
+			"integrity": "sha512-zxnIO/Rnf5bFWZN82REfXN0Oul3DWXV2ZCyuinGUpDVAyqQqYITIgq3l4sBdrr0ly6AB2e65+xMO/CCv5A94mA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@types/normalize-package-data": "^2.4.0",
-				"camelcase": "^5.3.1",
-				"chalk": "^2.4.2",
-				"errorish": "^0.4.0",
-				"execall": "^2.0.0",
-				"find-up": "^4.0.0",
-				"fs-extra": "^8.0.1",
-				"normalize-package-data": "^2.5.0"
+				"camelcase": "^8.0.0",
+				"chalk": "^5.0.1",
+				"errorish": "^1.0.0",
+				"execall": "^3.0.0",
+				"find-up": "^7.0.0",
+				"normalize-package-data": "^6.0.2"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=22"
+			}
+		},
+		"node_modules/cli-belt/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/clone-regexp": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
-			"integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
+			"integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"is-regexp": "^2.0.0"
+				"is-regexp": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/color-convert": {
@@ -142,6 +168,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
@@ -149,23 +176,26 @@
 		"node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/commander": {
-			"version": "9.4.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-			"integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || >=14"
 			}
 		},
 		"node_modules/common-tags": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+			"integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0.0"
 			}
@@ -174,125 +204,126 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/diff": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/errorish": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/errorish/-/errorish-0.4.0.tgz",
-			"integrity": "sha512-6bbH/9cgdngn9vrgEGaqhLX61yn0L/ub3Zl3cr3Emo2JxNR4viV+9T/LxWs+s2vRA2zeoyCTl+/gzufh+iBcuw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/errorish/-/errorish-1.0.0.tgz",
+			"integrity": "sha512-L02wV8ZV1ANodb8lyWOPSabE+Ogo1vP7zw9un0VRM8KdwvYF4sHI/7TliaUNC+FQUxxphcYHITeEo1MGcfE7LQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"promist": "^0.7.0"
+				"type-core": "^0.6.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
 			}
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
-		"node_modules/esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true,
-			"bin": {
-				"esparse": "bin/esparse.js",
-				"esvalidate": "bin/esvalidate.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/execall": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
-			"integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/execall/-/execall-3.0.0.tgz",
+			"integrity": "sha512-FaJeg2uWc8ADWnAnoDbxhAAr4U/j86ujlojnEpnBHQ4FM2viZKNjjyO2O6AKG6+9usZAnqsI4+1+w6vzx0x4uw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"clone-regexp": "^2.1.0"
+				"clone-regexp": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
-		"node_modules/fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+		"node_modules/fast-uri": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+			"integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
+			"integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
+				"locate-path": "^7.2.0",
+				"path-exists": "^5.0.0",
+				"unicorn-magic": "^0.1.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=6 <7 || >=8"
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/fs-readdir-recursive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
 			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true
-		},
-		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -309,43 +340,42 @@
 			}
 		},
 		"node_modules/graceful-fs": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-			"dev": true
-		},
-		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
-			"dependencies": {
-				"function-bind": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
+			"license": "ISC"
 		},
 		"node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/hosted-git-info": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-			"dev": true
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -355,92 +385,96 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"node_modules/is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
 			"dev": true,
-			"dependencies": {
-				"has": "^1.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
+			"license": "ISC"
 		},
 		"node_modules/is-regexp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
-			"integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+			"integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=6"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "^2.0.1"
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
 			}
 		},
 		"node_modules/locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+			"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"p-locate": "^4.1.0"
+				"p-locate": "^6.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/lodash.clonedeep": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-			"dev": true
 		},
 		"node_modules/lodash.mergewith": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
 			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/merge-strategies": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/merge-strategies/-/merge-strategies-0.1.6.tgz",
-			"integrity": "sha512-JaiqrKkE8Bw0WT7AKLyxGCIfN9LilaZ/K/sagxWqnN13LPi1IVMhsvieIQrTuBRjs2l6xQ77kyJo0Uo6J5iLYA==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/merge-strategies/-/merge-strategies-0.3.2.tgz",
+			"integrity": "sha512-K8XHSRh+NgrJpyMPS00PvEcXghoqMOgCyRzH1N3kUpcRNcoLSD5k2P6t8Ie5x73eT9NcgskoWhVHIUxTt0mMRg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"lodash.clonedeep": "^4.5.0",
 				"lodash.mergewith": "^4.6.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=22"
 			}
 		},
 		"node_modules/minimatch": {
@@ -448,6 +482,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -458,7 +493,7 @@
 		"node_modules/namify": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/namify/-/namify-0.1.3.tgz",
-			"integrity": "sha1-+ouxTViTRDqDppfq0MRoZP9Bvfo=",
+			"integrity": "sha512-NnrJy1rWMBb52xEAV5LusPx3UUln7rs1FdBnT3rJ4/aaD5MWZHgcVYZ8JLM3IUEUDj2A5XL0bUTUlMdwhBlviA==",
 			"dev": true,
 			"dependencies": {
 				"reserved": "^0.1.0"
@@ -468,15 +503,18 @@
 			}
 		},
 		"node_modules/normalize-package-data": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
-				"hosted-git-info": "^2.1.4",
-				"resolve": "^1.10.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "^7.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
 		"node_modules/once": {
@@ -484,53 +522,51 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
 			}
 		},
 		"node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"p-try": "^2.0.0"
+				"yocto-queue": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+			"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"p-limit": "^2.2.0"
+				"p-limit": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+			"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
 		"node_modules/path-is-absolute": {
@@ -538,123 +574,85 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
-		"node_modules/prettier": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-			"integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true,
-			"bin": {
-				"prettier": "bin/prettier.cjs"
-			},
+			"license": "MIT",
 			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
-		"node_modules/promist": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/promist/-/promist-0.7.0.tgz",
-			"integrity": "sha512-kcfKZ07y7P4LudEUGTcmO63g0L06+MyjzuYTfqghS0t/V8r52ovzVV1qkhc2GQrdy6NHS8kyUppCjMYTAQz27g==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/reserved": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/reserved/-/reserved-0.1.2.tgz",
-			"integrity": "sha1-cHsSRqMmn3Vdp8/Pmvb0mDvvEFw=",
+			"integrity": "sha512-/qO54MWj5L8WCBP9/UNe2iefJc+L9yETbH32xO/ft/EYPOTCR5k+azvDUgdCOKwZH8hXwPd0b8XBL78Nn2U69g==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/resolve": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-			"dev": true,
-			"dependencies": {
-				"is-core-module": "^2.1.0",
-				"path-parse": "^1.0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
-				"semver": "bin/semver"
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/spdx-correct": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"node_modules/spdx-exceptions": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-			"dev": true
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+			"dev": true,
+			"license": "CC-BY-3.0"
 		},
 		"node_modules/spdx-expression-parse": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
 			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
-			"dev": true
-		},
-		"node_modules/sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"version": "3.0.20",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
+			"integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -662,22 +660,37 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+		"node_modules/type-core": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/type-core/-/type-core-0.6.0.tgz",
+			"integrity": "sha512-2Wr5qtj4Vl3ZD3JaXheLz4BL+mXxuV9CjvuPl8dkqB/72FdvnuvkTp+WoGXDg9SpRlx1MkuTg7YgVXZSsrHuSw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">= 4.0.0"
+				"node": ">=12"
 			}
 		},
-		"node_modules/uri-js": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+		"node_modules/unicorn-magic": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
 			"dev": true,
-			"dependencies": {
-				"punycode": "^2.1.0"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/validate-npm-package-license": {
@@ -685,29 +698,34 @@
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"node_modules/vscode-oniguruma": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-			"integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
-			"dev": true
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/vscode-textmate": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.1.tgz",
-			"integrity": "sha512-zQ5U/nuXAAMsh691FtV0wPz89nSkHbs+IQV8FDk+wew9BlSDhf4UmWGlWJfTR2Ti6xZv87Tj5fENzKf6Qk7aLw==",
-			"dev": true
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.4.tgz",
+			"integrity": "sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/vscode-tmgrammar-test": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.1.1.tgz",
-			"integrity": "sha512-0WvD3U+E0KV95bNT7v5g7PQ85JfAjh9MuXOy1dgwZskkCsA8ASiSy60iv30JOZrM6dBjJZooGUAybRAIB+Song==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.1.3.tgz",
+			"integrity": "sha512-Wg6Pz+ePAT1O+F/A1Fc4wS5vY2X+HNtgN4qMdL+65NLQYd1/zdDWH4fhwsLjX8wTzeXkMy49Cr4ZqWTJ7VnVxg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
+				"bottleneck": "^2.19.5",
 				"chalk": "^2.4.2",
 				"commander": "^9.2.0",
 				"diff": "^4.0.2",
@@ -724,619 +742,43 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/yaml-import": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yaml-import/-/yaml-import-2.0.0.tgz",
-			"integrity": "sha512-2QfVEAmkPk+/L3XYqReD6qega0B1pfLtrgpD48ik38MI9CE/X51l5pdF883LiLaNPh/ssmH688xvdDfKkpqNhQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/yaml-import/-/yaml-import-3.0.0.tgz",
+			"integrity": "sha512-0B8HjiRSUxrErswjdmFWCZnDO4LmrWn1Kx9yPbKiXGzWt3ORSIzCRgqvkP9aMprFEeWo4D4hlGiRHLi5NPS1XA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"ajv": "^6.10.0",
-				"arg": "^4.1.0",
-				"cli-belt": "^0.3.1",
+				"ajv": "^8.17.1",
+				"arg": "^5.0.2",
+				"cli-belt": "^2.0.1",
 				"common-tags": "^1.8.0",
 				"fs-readdir-recursive": "^1.1.0",
-				"js-yaml": "^3.13.1",
-				"merge-strategies": "^0.1.1",
+				"js-yaml": "^4.1.0",
+				"merge-strategies": "^0.3.1",
 				"namify": "^0.1.3"
 			},
 			"bin": {
-				"yimp": "dist-node/bin/yimp.js"
+				"yimp": "build/bin/yimp.js"
 			},
 			"engines": {
-				"node": ">=8"
-			}
-		}
-	},
-	"dependencies": {
-		"@types/normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
-			"dev": true
-		},
-		"ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"dev": true,
-			"requires": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"node": ">=22"
 			}
 		},
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"requires": {
-				"color-convert": "^1.9.0"
-			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
-		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"requires": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
-		"balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
-		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			}
-		},
-		"cli-belt": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cli-belt/-/cli-belt-0.3.1.tgz",
-			"integrity": "sha512-cQfBIWcwZCXAGLLdyH5XAMmP3KWnqOTWH4HO8a2J/ALEHA59TzLQ+KeOxc2b1I1NSfekvchWexq4EnRctELo0g==",
-			"dev": true,
-			"requires": {
-				"@types/normalize-package-data": "^2.4.0",
-				"camelcase": "^5.3.1",
-				"chalk": "^2.4.2",
-				"errorish": "^0.4.0",
-				"execall": "^2.0.0",
-				"find-up": "^4.0.0",
-				"fs-extra": "^8.0.1",
-				"normalize-package-data": "^2.5.0"
-			}
-		},
-		"clone-regexp": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
-			"integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
-			"dev": true,
-			"requires": {
-				"is-regexp": "^2.0.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
-		},
-		"commander": {
-			"version": "9.4.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-			"integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
-			"dev": true
-		},
-		"common-tags": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
-			"dev": true
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true
-		},
-		"errorish": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/errorish/-/errorish-0.4.0.tgz",
-			"integrity": "sha512-6bbH/9cgdngn9vrgEGaqhLX61yn0L/ub3Zl3cr3Emo2JxNR4viV+9T/LxWs+s2vRA2zeoyCTl+/gzufh+iBcuw==",
-			"dev": true,
-			"requires": {
-				"promist": "^0.7.0"
-			}
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
-		},
-		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
-		},
-		"execall": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
-			"integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
-			"dev": true,
-			"requires": {
-				"clone-regexp": "^2.1.0"
-			}
-		},
-		"fast-deep-equal": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
-		},
-		"find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
-			"requires": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			}
-		},
-		"fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			}
-		},
-		"fs-readdir-recursive": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
-			"dev": true
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true
-		},
-		"function-bind": {
+		"node_modules/yocto-queue": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
-		"glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+			"integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
 			"dev": true,
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"graceful-fs": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
-		},
-		"hosted-git-info": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-			"dev": true
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
-			}
-		},
-		"is-regexp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
-			"integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
-			"dev": true
-		},
-		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
-			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			}
-		},
-		"json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
-		},
-		"jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
-			"requires": {
-				"p-locate": "^4.1.0"
-			}
-		},
-		"lodash.clonedeep": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-			"dev": true
-		},
-		"lodash.mergewith": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-			"dev": true
-		},
-		"merge-strategies": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/merge-strategies/-/merge-strategies-0.1.6.tgz",
-			"integrity": "sha512-JaiqrKkE8Bw0WT7AKLyxGCIfN9LilaZ/K/sagxWqnN13LPi1IVMhsvieIQrTuBRjs2l6xQ77kyJo0Uo6J5iLYA==",
-			"dev": true,
-			"requires": {
-				"lodash.clonedeep": "^4.5.0",
-				"lodash.mergewith": "^4.6.1"
-			}
-		},
-		"minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"namify": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/namify/-/namify-0.1.3.tgz",
-			"integrity": "sha1-+ouxTViTRDqDppfq0MRoZP9Bvfo=",
-			"dev": true,
-			"requires": {
-				"reserved": "^0.1.0"
-			}
-		},
-		"normalize-package-data": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-			"dev": true,
-			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"resolve": "^1.10.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
-			}
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"requires": {
-				"p-try": "^2.0.0"
-			}
-		},
-		"p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"requires": {
-				"p-limit": "^2.2.0"
-			}
-		},
-		"p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true
-		},
-		"path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"dev": true
-		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
-		"prettier": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-			"integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-			"dev": true
-		},
-		"promist": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/promist/-/promist-0.7.0.tgz",
-			"integrity": "sha512-kcfKZ07y7P4LudEUGTcmO63g0L06+MyjzuYTfqghS0t/V8r52ovzVV1qkhc2GQrdy6NHS8kyUppCjMYTAQz27g==",
-			"dev": true
-		},
-		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
-		},
-		"reserved": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/reserved/-/reserved-0.1.2.tgz",
-			"integrity": "sha1-cHsSRqMmn3Vdp8/Pmvb0mDvvEFw=",
-			"dev": true
-		},
-		"resolve": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.1.0",
-				"path-parse": "^1.0.6"
-			}
-		},
-		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
-		},
-		"spdx-correct": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-			"dev": true,
-			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"spdx-exceptions": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-			"dev": true
-		},
-		"spdx-expression-parse": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-			"dev": true,
-			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"spdx-license-ids": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
-			"dev": true
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
-		},
-		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
-		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true
-		},
-		"uri-js": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
-			"dev": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
-		},
-		"validate-npm-package-license": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-			"dev": true,
-			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
-			}
-		},
-		"vscode-oniguruma": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-			"integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
-			"dev": true
-		},
-		"vscode-textmate": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.1.tgz",
-			"integrity": "sha512-zQ5U/nuXAAMsh691FtV0wPz89nSkHbs+IQV8FDk+wew9BlSDhf4UmWGlWJfTR2Ti6xZv87Tj5fENzKf6Qk7aLw==",
-			"dev": true
-		},
-		"vscode-tmgrammar-test": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.1.1.tgz",
-			"integrity": "sha512-0WvD3U+E0KV95bNT7v5g7PQ85JfAjh9MuXOy1dgwZskkCsA8ASiSy60iv30JOZrM6dBjJZooGUAybRAIB+Song==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.2",
-				"commander": "^9.2.0",
-				"diff": "^4.0.2",
-				"glob": "^7.1.6",
-				"vscode-oniguruma": "^1.5.1",
-				"vscode-textmate": "^7.0.1"
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
-		},
-		"yaml-import": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yaml-import/-/yaml-import-2.0.0.tgz",
-			"integrity": "sha512-2QfVEAmkPk+/L3XYqReD6qega0B1pfLtrgpD48ik38MI9CE/X51l5pdF883LiLaNPh/ssmH688xvdDfKkpqNhQ==",
-			"dev": true,
-			"requires": {
-				"ajv": "^6.10.0",
-				"arg": "^4.1.0",
-				"cli-belt": "^0.3.1",
-				"common-tags": "^1.8.0",
-				"fs-readdir-recursive": "^1.1.0",
-				"js-yaml": "^3.13.1",
-				"merge-strategies": "^0.1.1",
-				"namify": "^0.1.3"
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
 	"version": "1.7.0",
 	"publisher": "bpruitt-goddard",
 	"license": "MIT",
+	"type": "module",
 	"engines": {
-		"vscode": "^1.19.0"
+		"vscode": "^1.19.0",
+		"node": ">=22.0.0"
 	},
 	"categories": [
 		"Other"
@@ -68,16 +70,17 @@
 		"mermaid"
 	],
 	"scripts": {
-		"vscode:prepublish": "npm run convertYaml",
-		"convertYaml": "node build/ConvertYaml.js",
+		"convertYaml": "node build/ConvertYaml.mjs",
+    "format:write": "prettier --write syntaxes",
 		"test": "vscode-tmgrammar-test \"tests/**/*.test.{mermaid,md,mdx}\"",
-		"format:write": "prettier --write syntaxes"
+    "vscode:prepublish": "npm run convertYaml"
 	},
 	"devDependencies": {
-		"js-yaml": "^3.13.1",
-		"prettier": "^3.3.3",
-		"vscode-tmgrammar-test": "^0.1.1",
-		"yaml-import": "^2.0.0"
+		"fs-extra": "^11.2.0",
+		"js-yaml": "^4.1.0",
+    "prettier": "^3.3.3",
+		"vscode-tmgrammar-test": "^0.1.3",
+		"yaml-import": "^3.0.0"
 	},
 	"__metadata": {
 		"id": "08792992-bb56-41fb-b5dd-8551bbee0cb6",

--- a/package.json
+++ b/package.json
@@ -71,14 +71,14 @@
 	],
 	"scripts": {
 		"convertYaml": "node build/ConvertYaml.mjs",
-    "format:write": "prettier --write syntaxes",
+		"format:write": "prettier --write syntaxes",
 		"test": "vscode-tmgrammar-test \"tests/**/*.test.{mermaid,md,mdx}\"",
-    "vscode:prepublish": "npm run convertYaml"
+		"vscode:prepublish": "npm run convertYaml"
 	},
 	"devDependencies": {
 		"fs-extra": "^11.2.0",
 		"js-yaml": "^4.1.0",
-    "prettier": "^3.3.3",
+		"prettier": "^3.3.3",
 		"vscode-tmgrammar-test": "^0.1.3",
 		"yaml-import": "^3.0.0"
 	},


### PR DESCRIPTION
Updates dependencies including to latest Node LTS.  Latest version of `yaml-import` now only supports ESM, so also migrates to using import syntax.

Adjusts the contributing document to reference the new name of the vsce CLI package.