### PR TITLE
feat: (graph) support extended node shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.7.1]
+
+- Add support for extended node shapes (graph/flowchart)
+
 ## [v1.7.0]
 
 - Add architecture diagram support

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Mermaid Markdown Syntax Highlighting",
 	"description": "Markdown syntax support for the Mermaid charting language",
 	"icon": "images/icon/iconPNG.png",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"publisher": "bpruitt-goddard",
 	"license": "MIT",
 	"type": "module",

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -187,7 +187,7 @@
           name: variable
         '4':
           name: string
-    - comment: (ExtendedNodeDescription)
+    - comment: (ExtendedOpeningBrace)(NodeDescription1)(NodeDescription2)(ExtendedClosingBrace)
       match: !regex |-
         \s*(\@\{) # Opening brace
         \s*((?:shape|label)\:)?([^\,]*) # Node description 1 (e.g. shape: odd)

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -187,25 +187,34 @@
           name: variable
         '4':
           name: string
-    - comment: (ExtendedOpeningBrace)(shape/label 1)(shape/label text 1)(shape/label 2)(shape/label text 2)(ExtendedClosingBrace)
-      match: !regex |-
-        \s*(\@\{) # Opening brace
-        \s*((?:shape|label)\:)?([^\,]*) # Node description 1 (e.g. shape: odd)
-        (?:(\,)\s*((?:label|shape)\:)?(.*))? # Node description 2 (e.g. label: "Odd")
-        (\}) # Closing brace
-      captures:
-        '1':
+    - comment: ExtendedNodeShapes
+      begin: \s*(\@\{)
+      beginCaptures:
+        '1': 
           name: keyword.control.mermaid
-        '2':
-          name: keyword.control.mermaid
-        '3':
-          name: string
-        '4':
-          name: keyword.control.mermaid
-        '5':
-          name: keyword.control.mermaid
-        '6':
-          name: string
-        '7':
+      patterns:
+        - comment: (shape)(shape name)(comma)?
+          match: !regex |-
+            \s*(shape\s*\:)([^\,\}]*)(\,)?
+          captures:
+            '1':
+              name: keyword.control.mermaid
+            '2':
+              name: entity.name.function.mermaid
+            '3':
+              name: keyword.control.mermaid
+        - comment: (label)(label text)(comma)?
+          match: !regex |-
+            \s*(label\s*\:)([^\,\}]*)(\,)?
+          captures:
+            '1':
+              name: keyword.control.mermaid
+            '2':
+              name: string
+            '3':
+              name: keyword.control.mermaid
+      end: (\})
+      endCaptures: 
+        '1': 
           name: keyword.control.mermaid
   end: (^|\G)(?=\s*[`:~]{3,}\s*$)

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -190,7 +190,7 @@
     - comment: ExtendedNodeShapes
       begin: \s*(\@\{)
       beginCaptures:
-        '1': 
+        '1':
           name: keyword.control.mermaid
       patterns:
         - comment: (shape)(shape name)(comma)?
@@ -214,7 +214,7 @@
             '3':
               name: keyword.control.mermaid
       end: (\})
-      endCaptures: 
-        '1': 
+      endCaptures:
+        '1':
           name: keyword.control.mermaid
   end: (^|\G)(?=\s*[`:~]{3,}\s*$)

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -1,5 +1,5 @@
 - comment: Graph
-  begin: ^\s*(graph|flowchart)\s+([\p{Letter}\ 0-9]+)
+  begin: ^\s*(graph|flowchart)\s+([\p{Letter}\ 0-9]+)?
   beginCaptures:
     '1':
       name: keyword.control.mermaid
@@ -187,4 +187,25 @@
           name: variable
         '4':
           name: string
+    - comment: (ExtendedNodeDescription)
+      match: !regex |-
+        \s*(\@\{) # Opening brace
+        \s*((?:shape|label)\:)?([^\,]*) # Node description 1 (e.g. shape: odd)
+        (?:(\,)\s*((?:label|shape)\:)?(.*))? # Node description 2 (e.g. label: "Odd")
+        (\}) # Closing brace
+      captures:
+        '1':
+          name: keyword.control.mermaid
+        '2':
+          name: entity.name.function.mermaid
+        '3':
+          name: string
+        '4':
+          name: keyword.control.mermaid
+        '5':
+          name: entity.name.function.mermaid
+        '6': 
+          name: string
+        '7':
+          name: keyword.control.mermaid
   end: (^|\G)(?=\s*[`:~]{3,}\s*$)

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -187,7 +187,7 @@
           name: variable
         '4':
           name: string
-    - comment: (ExtendedOpeningBrace)(NodeDescription1)(NodeDescription2)(ExtendedClosingBrace)
+    - comment: (ExtendedOpeningBrace)(shape/label 1)(shape/label text 1)(shape/label 2)(shape/label text 2)(ExtendedClosingBrace)
       match: !regex |-
         \s*(\@\{) # Opening brace
         \s*((?:shape|label)\:)?([^\,]*) # Node description 1 (e.g. shape: odd)
@@ -197,13 +197,13 @@
         '1':
           name: keyword.control.mermaid
         '2':
-          name: entity.name.function.mermaid
+          name: keyword.control.mermaid
         '3':
           name: string
         '4':
           name: keyword.control.mermaid
         '5':
-          name: entity.name.function.mermaid
+          name: keyword.control.mermaid
         '6':
           name: string
         '7':

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -204,7 +204,7 @@
           name: keyword.control.mermaid
         '5':
           name: entity.name.function.mermaid
-        '6': 
+        '6':
           name: string
         '7':
           name: keyword.control.mermaid

--- a/tests/diagrams/graph-flowchart.test.mermaid
+++ b/tests/diagrams/graph-flowchart.test.mermaid
@@ -1,6 +1,7 @@
 %% SYNTAX TEST "source.mermaid" "graph flowchart test"
 
-flowchart TB
+flowchart
+%% <--------- keyword.control.mermaid 
   ID-1[Node 1]
 %%^^^^ variable
 %%    ^ keyword.control.mermaid 

--- a/tests/diagrams/graph-flowchart.test.mermaid
+++ b/tests/diagrams/graph-flowchart.test.mermaid
@@ -1,7 +1,6 @@
 %% SYNTAX TEST "source.mermaid" "graph flowchart test"
 
-flowchart
-%% <--------- keyword.control.mermaid 
+flowchart TB
   ID-1[Node 1]
 %%^^^^ variable
 %%    ^ keyword.control.mermaid 

--- a/tests/diagrams/graph.test.mermaid
+++ b/tests/diagrams/graph.test.mermaid
@@ -297,3 +297,38 @@ end
   %% negative cases
   invalid subgraph invalid
 %%^^^^^^^^^^^^^^^^^^^^^^^^ source.mermaid - keyword.control.mermaid
+  
+  %% extended node shapes
+text@{shape: odd, label: "asd</br>asd"}
+%% <---- variable
+%%  ^^ keyword.control.mermaid
+%%    ^^^^^^ keyword.control.mermaid
+%%          ^^^^ string
+%%              ^ keyword.control.mermaid
+%%                ^^^^^^ keyword.control.mermaid
+%%                      ^^^^^^^^^^^^^^ string
+%%                                    ^ keyword.control.mermaid
+  %% different description order, no space between, no "
+text@{label: text,shape: odd}
+%% <---- variable
+%%  ^^ keyword.control.mermaid
+%%    ^^^^^^ keyword.control.mermaid
+%%          ^^^^^ string
+%%               ^ keyword.control.mermaid
+%%                 ^^^^^ keyword.control.mermaid
+%%                      ^^^^ string
+%%                          ^ keyword.control.mermaid
+  %% single prop in description (label)
+text@{label: text}
+%% <---- variable
+%%  ^^ keyword.control.mermaid
+%%    ^^^^^^ keyword.control.mermaid
+%%          ^^^^^ string
+%%               ^ keyword.control.mermaid
+  %% single prop in description (shape)
+text@{shape: lean-r}
+%% <---- variable
+%%  ^^ keyword.control.mermaid
+%%    ^^^^^^ keyword.control.mermaid
+%%          ^^^^^^^ string
+%%                 ^ keyword.control.mermaid

--- a/tests/diagrams/graph.test.mermaid
+++ b/tests/diagrams/graph.test.mermaid
@@ -303,7 +303,7 @@ text@{shape: odd, label: "asd</br>asd"}
 %% <---- variable
 %%  ^^ keyword.control.mermaid
 %%    ^^^^^^ keyword.control.mermaid
-%%          ^^^^ string
+%%          ^^^^ entity.name.function.mermaid
 %%              ^ keyword.control.mermaid
 %%                ^^^^^^ keyword.control.mermaid
 %%                      ^^^^^^^^^^^^^^ string
@@ -316,7 +316,7 @@ text@{label: text,shape: odd}
 %%          ^^^^^ string
 %%               ^ keyword.control.mermaid
 %%                 ^^^^^ keyword.control.mermaid
-%%                      ^^^^ string
+%%                      ^^^^ entity.name.function.mermaid
 %%                          ^ keyword.control.mermaid
   %% single prop in description (label)
 text@{label: text}
@@ -330,5 +330,12 @@ text@{shape: lean-r}
 %% <---- variable
 %%  ^^ keyword.control.mermaid
 %%    ^^^^^^ keyword.control.mermaid
-%%          ^^^^^^^ string
+%%          ^^^^^^^ entity.name.function.mermaid
 %%                 ^ keyword.control.mermaid
+  %% space between 'shape' and ':'
+text@{shape   : lean-r}
+%% <---- variable
+%%  ^^ keyword.control.mermaid
+%%    ^^^^^^^^^ keyword.control.mermaid
+%%             ^^^^^^^ entity.name.function.mermaid
+%%                    ^ keyword.control.mermaid


### PR DESCRIPTION
- Adds support for extended node shapes
- Also adds support for implicit graph direction as mermaid allows it (and defaults to TB)

Before:
<details><summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/c7ac2c1b-886e-4710-93e2-d56afd73b633)
![image](https://github.com/user-attachments/assets/7faa4343-9028-458f-a78d-b51e7b35b100)

</details>

After:
<details><summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/41ce3325-d271-4a61-967f-055631338828)


</details>