### PR TITLE
fix: dotted graph links syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.7.2]
+
+- Add support for a dotted link syntax variation without leading dash
+
 ## [v1.7.1]
 
 - Add support for extended node shapes (graph/flowchart)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Mermaid Markdown Syntax Highlighting",
 	"description": "Markdown syntax support for the Mermaid charting language",
 	"icon": "images/icon/iconPNG.png",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"publisher": "bpruitt-goddard",
 	"license": "MIT",
 	"type": "module",

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -88,7 +88,7 @@
           name: keyword.control.mermaid
     - comment: (Graph Link)("Multiline text")(Graph Link)
       begin: !regex |-
-        \s*((?:\-?.{1,4}-|-{2,5}|={2,5})[xo>]?\|) # Start arrow
+        \s*((?:-?\.{1,4}-|-{2,5}|={2,5})[xo>]?\|) # Start arrow
       beginCaptures:
         '1':
           name: keyword.control.mermaid
@@ -141,7 +141,7 @@
           name: keyword.control.mermaid
     - comment: (Graph Link)
       match: !regex |-
-        \s*([ox<]?(?:-?.{1,4}-|-{1,4}|={1,4})[ox>]?) # Graph Link
+        \s*([ox<]?(?:-?\.{1,4}-|-{1,4}|={1,4})[ox>]?) # Graph Link
       captures:
         '1':
           name: keyword.control.mermaid

--- a/syntaxes/diagrams/graph.yaml
+++ b/syntaxes/diagrams/graph.yaml
@@ -88,7 +88,7 @@
           name: keyword.control.mermaid
     - comment: (Graph Link)("Multiline text")(Graph Link)
       begin: !regex |-
-        \s*((?:-{2,5}|={2,5})[xo>]?\|) # Start arrow
+        \s*((?:\-?.{1,4}-|-{2,5}|={2,5})[xo>]?\|) # Start arrow
       beginCaptures:
         '1':
           name: keyword.control.mermaid
@@ -141,7 +141,7 @@
           name: keyword.control.mermaid
     - comment: (Graph Link)
       match: !regex |-
-        \s*([ox<]?(?:-.{1,3}-|-{1,3}|={1,3})[ox>]?) # Graph Link
+        \s*([ox<]?(?:-?.{1,4}-|-{1,4}|={1,4})[ox>]?) # Graph Link
       captures:
         '1':
           name: keyword.control.mermaid

--- a/tests/diagrams/graph.test.mermaid
+++ b/tests/diagrams/graph.test.mermaid
@@ -245,6 +245,22 @@ graph TB
 %%          ^^^^^^^^^^^^^^^^^^ string
 %%                             ^^  keyword.control.mermaid
 %%                                 ^^^^ variable
+    ID-4.->ID-5
+%%  ^^^^ variable
+%%      ^^^  keyword.control.mermaid
+%%         ^^^^ variable
+    ID-2 -.-|Text| ID-2
+%%  ^^^^ variable
+%%       ^^^^ keyword.control.mermaid
+%%           ^^^^ string
+%%               ^ keyword.control.mermaid
+%%                 ^^^^ variable
+    ID-2 ..-|Text| ID-2
+%%  ^^^^ variable
+%%       ^^^^ keyword.control.mermaid
+%%           ^^^^ string
+%%               ^ keyword.control.mermaid
+%%                 ^^^^ variable
     ID-5==>ID-6
 %%  ^^^^ variable
 %%      ^^^  keyword.control.mermaid


### PR DESCRIPTION
Adds support for a dotted link syntax variation without leading dash (`-.->` & `.->` are both valid) as well as support for arrow label `|Text|` notation without `>` symbol

Before:
<details><summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/9f9ebc3e-14b6-40d2-80c6-e42194f35580)

</details>

After:
<details><summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/59c471ce-8d5e-4c00-87a0-feeb32c848d5)

</details>

